### PR TITLE
Refactor architecture: extract shared widgets, fix provider locations, improve reactivity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Material 3 with `dynamic_color` support. Custom `FinanceColors` theme extension 
 - **Targets**: Android + Linux desktop only. `dart:ffi` dependency means web builds fail.
 - **Flutter 3.38+**: `DropdownButtonFormField` uses `initialValue` (not deprecated `value` parameter).
 - **Category seeding**: `CategorySeeder` runs on first launch in `main.dart`, populating 16 expense + 7 income parent categories with subcategories.
-- **Account types**: 18 types defined in `accounts_providers.dart` with `AccountTypeInfo` metadata and `accountTypeGroups` for UI grouping.
+- **Account types**: 18 types defined in `core/constants/account_types.dart` with `AccountTypeInfo` metadata and `accountTypeGroups` for UI grouping (re-exported from `accounts_providers.dart`).
 - **Expenses stored as negative cents**: Income is positive, expenses are negative in `amountCents`.
 
 ## Current Status

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,26 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dynamic_color/dynamic_color.dart';
-import 'package:go_router/go_router.dart';
 
 import 'core/constants/app_constants.dart';
 import 'core/di/providers.dart';
-import 'core/theme/app_theme.dart';
 import 'core/router/app_router.dart';
-
-/// Provider for the current theme mode.
-final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.system);
-
-/// Provider for the app router (needs Ref for auth redirect logic).
-final appRouterProvider = Provider<GoRouter>((ref) {
-  return createAppRouter(ref);
-});
-
-/// Whether the app is currently unlocked (past the lock screen).
-final isUnlockedProvider = StateProvider<bool>((ref) => false);
-
-/// Tracks the last time the app was paused (backgrounded).
-final lastPausedAtProvider = StateProvider<DateTime?>((ref) => null);
+import 'core/theme/app_theme.dart';
 
 /// Root application widget.
 class PatrimoniumApp extends ConsumerWidget {

--- a/lib/core/constants/account_types.dart
+++ b/lib/core/constants/account_types.dart
@@ -1,0 +1,62 @@
+/// Metadata for a single account type.
+class AccountTypeInfo {
+  final String key;
+  final String label;
+  final String icon;
+  final bool isAsset;
+
+  const AccountTypeInfo({
+    required this.key,
+    required this.label,
+    required this.icon,
+    required this.isAsset,
+  });
+}
+
+/// All supported account types with display metadata.
+const accountTypes = [
+  AccountTypeInfo(key: 'checking', label: 'Checking', icon: 'account_balance', isAsset: true),
+  AccountTypeInfo(key: 'savings', label: 'Savings', icon: 'savings', isAsset: true),
+  AccountTypeInfo(key: 'credit_card', label: 'Credit Card', icon: 'credit_card', isAsset: false),
+  AccountTypeInfo(key: 'brokerage', label: 'Brokerage', icon: 'trending_up', isAsset: true),
+  AccountTypeInfo(key: '401k', label: '401(k)', icon: 'account_balance_wallet', isAsset: true),
+  AccountTypeInfo(key: 'ira', label: 'IRA', icon: 'account_balance_wallet', isAsset: true),
+  AccountTypeInfo(key: 'roth_ira', label: 'Roth IRA', icon: 'account_balance_wallet', isAsset: true),
+  AccountTypeInfo(key: 'hsa', label: 'HSA', icon: 'health_and_safety', isAsset: true),
+  AccountTypeInfo(key: 'mortgage', label: 'Mortgage', icon: 'house', isAsset: false),
+  AccountTypeInfo(key: 'auto_loan', label: 'Auto Loan', icon: 'directions_car', isAsset: false),
+  AccountTypeInfo(key: 'student_loan', label: 'Student Loan', icon: 'school', isAsset: false),
+  AccountTypeInfo(key: 'personal_loan', label: 'Personal Loan', icon: 'money', isAsset: false),
+  AccountTypeInfo(key: 'line_of_credit', label: 'Line of Credit', icon: 'credit_score', isAsset: false),
+  AccountTypeInfo(key: 'real_estate', label: 'Real Estate', icon: 'home_work', isAsset: true),
+  AccountTypeInfo(key: 'vehicle', label: 'Vehicle', icon: 'directions_car', isAsset: true),
+  AccountTypeInfo(key: 'crypto', label: 'Crypto', icon: 'currency_bitcoin', isAsset: true),
+  AccountTypeInfo(key: 'other_asset', label: 'Other Asset', icon: 'category', isAsset: true),
+  AccountTypeInfo(key: 'other_liability', label: 'Other Liability', icon: 'money_off', isAsset: false),
+];
+
+/// Get display label for an account type key.
+String getAccountTypeLabel(String typeKey) {
+  return accountTypes
+      .where((t) => t.key == typeKey)
+      .map((t) => t.label)
+      .firstOrNull ?? typeKey;
+}
+
+/// Get whether an account type is an asset.
+bool isAccountTypeAsset(String typeKey) {
+  return accountTypes
+      .where((t) => t.key == typeKey)
+      .map((t) => t.isAsset)
+      .firstOrNull ?? true;
+}
+
+/// Account type grouping for display.
+const accountTypeGroups = {
+  'Cash': ['checking', 'savings'],
+  'Credit Cards': ['credit_card', 'line_of_credit'],
+  'Investments': ['brokerage', '401k', 'ira', 'roth_ira', 'hsa'],
+  'Loans': ['mortgage', 'auto_loan', 'student_loan', 'personal_loan'],
+  'Property': ['real_estate', 'vehicle'],
+  'Other': ['crypto', 'other_asset', 'other_liability'],
+};

--- a/lib/core/error/app_error.dart
+++ b/lib/core/error/app_error.dart
@@ -136,6 +136,15 @@ class LLMError extends AppError {
       );
 }
 
+/// Unexpected errors that don't fit a specific category.
+class UnexpectedError extends AppError {
+  const UnexpectedError({
+    required super.message,
+    super.technicalDetails,
+    super.originalError,
+  });
+}
+
 /// Import/export errors.
 class ImportError extends AppError {
   final int? failedRow;
@@ -185,7 +194,7 @@ class ErrorHandler {
     }
 
     // Fallback
-    return NetworkError(
+    return UnexpectedError(
       message: 'An unexpected error occurred. Please try again.',
       technicalDetails: message,
       originalError: error,

--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -178,6 +178,16 @@ class TransactionRepository {
     return result.isNotEmpty;
   }
 
+  /// Get count of uncategorized transactions.
+  Future<int> getUncategorizedCount() async {
+    final count = _db.transactions.id.count();
+    final result = await (_db.selectOnly(_db.transactions)
+          ..where(_db.transactions.categoryId.isNull())
+          ..addColumns([count]))
+        .getSingle();
+    return result.read(count) ?? 0;
+  }
+
   /// Get transaction count.
   Future<int> getTransactionCount() async {
     final count = _db.transactions.id.count();

--- a/lib/domain/usecases/auth/pin_service.dart
+++ b/lib/domain/usecases/auth/pin_service.dart
@@ -62,15 +62,6 @@ class PinService {
   /// Remove PIN (used for reset).
   Future<void> clearPin() => _storage.clearPin();
 
-  // ─── Biometric ────────────────────────────────────────────────────
-
-  /// Check if biometric auth is enabled.
-  Future<bool> isBiometricEnabled() => _storage.isBiometricEnabled();
-
-  /// Enable or disable biometric authentication.
-  Future<void> setBiometricEnabled(bool enabled) =>
-      _storage.setBiometricEnabled(enabled);
-
   // ─── PBKDF2 Implementation ────────────────────────────────────────
 
   /// Generate a cryptographically secure random salt.

--- a/lib/presentation/features/accounts/accounts_providers.dart
+++ b/lib/presentation/features/accounts/accounts_providers.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/di/providers.dart';
 import '../../../data/local/database/app_database.dart';
 
+// Re-export account type constants so existing imports continue to work.
+export '../../../core/constants/account_types.dart';
+
 /// Watch all visible accounts.
 final accountsProvider = StreamProvider.autoDispose<List<Account>>((ref) {
   return ref.watch(accountRepositoryProvider).watchAllAccounts();
@@ -13,9 +16,15 @@ final allAccountsProvider = StreamProvider.autoDispose<List<Account>>((ref) {
   return ref.watch(accountRepositoryProvider).watchAllAccountsIncludingHidden();
 });
 
-/// Watch accounts grouped by type.
-final accountsByTypeProvider = FutureProvider.autoDispose<Map<String, List<Account>>>((ref) {
-  return ref.watch(accountRepositoryProvider).getAccountsByType();
+/// Watch accounts grouped by type (reactive via stream).
+final accountsByTypeProvider = StreamProvider.autoDispose<Map<String, List<Account>>>((ref) {
+  return ref.watch(accountRepositoryProvider).watchAllAccounts().map((accounts) {
+    final grouped = <String, List<Account>>{};
+    for (final account in accounts) {
+      grouped.putIfAbsent(account.accountType, () => []).add(account);
+    }
+    return grouped;
+  });
 });
 
 /// Watch net worth.
@@ -23,79 +32,21 @@ final netWorthProvider = StreamProvider.autoDispose<int>((ref) {
   return ref.watch(accountRepositoryProvider).watchNetWorth();
 });
 
-/// Watch total assets.
-final totalAssetsProvider = FutureProvider.autoDispose<int>((ref) {
-  return ref.watch(accountRepositoryProvider).getTotalAssets();
+/// Watch total assets (reactive via stream).
+final totalAssetsProvider = StreamProvider.autoDispose<int>((ref) {
+  return ref.watch(accountRepositoryProvider).watchAllAccounts().map((accounts) {
+    return accounts.where((a) => a.isAsset).fold<int>(0, (sum, a) => sum + a.balanceCents);
+  });
 });
 
-/// Watch total liabilities.
-final totalLiabilitiesProvider = FutureProvider.autoDispose<int>((ref) {
-  return ref.watch(accountRepositoryProvider).getTotalLiabilities();
+/// Watch total liabilities (reactive via stream).
+final totalLiabilitiesProvider = StreamProvider.autoDispose<int>((ref) {
+  return ref.watch(accountRepositoryProvider).watchAllAccounts().map((accounts) {
+    return accounts.where((a) => !a.isAsset).fold<int>(0, (sum, a) => sum + a.balanceCents);
+  });
 });
 
 /// Watch a single account by ID.
 final accountByIdProvider = StreamProvider.autoDispose.family<Account?, String>((ref, id) {
   return ref.watch(accountRepositoryProvider).watchAccountById(id);
 });
-
-/// Account type metadata for display.
-class AccountTypeInfo {
-  final String key;
-  final String label;
-  final String icon;
-  final bool isAsset;
-
-  const AccountTypeInfo({
-    required this.key,
-    required this.label,
-    required this.icon,
-    required this.isAsset,
-  });
-}
-
-const accountTypes = [
-  AccountTypeInfo(key: 'checking', label: 'Checking', icon: 'account_balance', isAsset: true),
-  AccountTypeInfo(key: 'savings', label: 'Savings', icon: 'savings', isAsset: true),
-  AccountTypeInfo(key: 'credit_card', label: 'Credit Card', icon: 'credit_card', isAsset: false),
-  AccountTypeInfo(key: 'brokerage', label: 'Brokerage', icon: 'trending_up', isAsset: true),
-  AccountTypeInfo(key: '401k', label: '401(k)', icon: 'account_balance_wallet', isAsset: true),
-  AccountTypeInfo(key: 'ira', label: 'IRA', icon: 'account_balance_wallet', isAsset: true),
-  AccountTypeInfo(key: 'roth_ira', label: 'Roth IRA', icon: 'account_balance_wallet', isAsset: true),
-  AccountTypeInfo(key: 'hsa', label: 'HSA', icon: 'health_and_safety', isAsset: true),
-  AccountTypeInfo(key: 'mortgage', label: 'Mortgage', icon: 'house', isAsset: false),
-  AccountTypeInfo(key: 'auto_loan', label: 'Auto Loan', icon: 'directions_car', isAsset: false),
-  AccountTypeInfo(key: 'student_loan', label: 'Student Loan', icon: 'school', isAsset: false),
-  AccountTypeInfo(key: 'personal_loan', label: 'Personal Loan', icon: 'money', isAsset: false),
-  AccountTypeInfo(key: 'line_of_credit', label: 'Line of Credit', icon: 'credit_score', isAsset: false),
-  AccountTypeInfo(key: 'real_estate', label: 'Real Estate', icon: 'home_work', isAsset: true),
-  AccountTypeInfo(key: 'vehicle', label: 'Vehicle', icon: 'directions_car', isAsset: true),
-  AccountTypeInfo(key: 'crypto', label: 'Crypto', icon: 'currency_bitcoin', isAsset: true),
-  AccountTypeInfo(key: 'other_asset', label: 'Other Asset', icon: 'category', isAsset: true),
-  AccountTypeInfo(key: 'other_liability', label: 'Other Liability', icon: 'money_off', isAsset: false),
-];
-
-/// Get display label for an account type key.
-String getAccountTypeLabel(String typeKey) {
-  return accountTypes
-      .where((t) => t.key == typeKey)
-      .map((t) => t.label)
-      .firstOrNull ?? typeKey;
-}
-
-/// Get whether an account type is an asset.
-bool isAccountTypeAsset(String typeKey) {
-  return accountTypes
-      .where((t) => t.key == typeKey)
-      .map((t) => t.isAsset)
-      .firstOrNull ?? true;
-}
-
-/// Account type grouping for display.
-const accountTypeGroups = {
-  'Cash': ['checking', 'savings'],
-  'Credit Cards': ['credit_card', 'line_of_credit'],
-  'Investments': ['brokerage', '401k', 'ira', 'roth_ira', 'hsa'],
-  'Loans': ['mortgage', 'auto_loan', 'student_loan', 'personal_loan'],
-  'Property': ['real_estate', 'vehicle'],
-  'Other': ['crypto', 'other_asset', 'other_liability'],
-};

--- a/lib/presentation/features/auth/lock_screen.dart
+++ b/lib/presentation/features/auth/lock_screen.dart
@@ -3,9 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../app.dart';
 import '../../../core/constants/app_constants.dart';
 import '../../../core/di/providers.dart';
+import '../../../core/router/app_router.dart';
 import '../../shared/widgets/pin_number_pad.dart';
 
 /// Lock screen with PIN entry and optional biometric authentication.
@@ -66,7 +66,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
     if (isValid) {
       // Mark as unlocked and navigate to dashboard
       ref.read(isUnlockedProvider.notifier).state = true;
-      context.go('/dashboard');
+      context.go(AppRoutes.dashboard);
     } else {
       setState(() {
         _isError = true;
@@ -109,7 +109,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
 
     if (success) {
       ref.read(isUnlockedProvider.notifier).state = true;
-      context.go('/dashboard');
+      context.go(AppRoutes.dashboard);
     }
   }
 

--- a/lib/presentation/features/auth/pin_setup_screen.dart
+++ b/lib/presentation/features/auth/pin_setup_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../app.dart';
 import '../../../core/di/providers.dart';
 import '../../../core/router/app_router.dart';
 import '../../shared/widgets/pin_number_pad.dart';

--- a/lib/presentation/features/settings/settings_screen.dart
+++ b/lib/presentation/features/settings/settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../app.dart';
 import '../../../core/constants/app_constants.dart';
 import '../../../core/di/providers.dart';
 import '../../../core/router/app_router.dart';

--- a/lib/presentation/features/transactions/transactions_providers.dart
+++ b/lib/presentation/features/transactions/transactions_providers.dart
@@ -3,6 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/di/providers.dart';
 import '../../../data/local/database/app_database.dart';
 
+// Re-export category providers so existing imports continue to work.
+export '../../../core/di/providers.dart'
+    show allCategoriesProvider, expenseCategoriesProvider, incomeCategoriesProvider;
+
 // =============================================================================
 // FILTER STATE
 // =============================================================================
@@ -140,11 +144,11 @@ final accountTransactionsProvider =
       .watchTransactionsForAccount(accountId);
 });
 
-/// Recent transactions for dashboard (last 10).
-final recentTransactionsProvider = FutureProvider.autoDispose<List<Transaction>>((ref) {
+/// Recent transactions for dashboard (last 10, reactive via stream).
+final recentTransactionsProvider = StreamProvider.autoDispose<List<Transaction>>((ref) {
   return ref
       .watch(transactionRepositoryProvider)
-      .getRecentTransactions(limit: 10);
+      .watchRecentTransactions(limit: 10);
 });
 
 /// Total income for current month.
@@ -172,25 +176,9 @@ final monthlyExpensesProvider = FutureProvider.autoDispose<int>((ref) {
 /// Search query state.
 final transactionSearchQueryProvider = StateProvider<String>((ref) => '');
 
-/// Uncategorized transaction count.
-final uncategorizedCountProvider = FutureProvider.autoDispose<int>((ref) async {
-  final transactions = await ref
+/// Uncategorized transaction count (uses count query, not full fetch).
+final uncategorizedCountProvider = FutureProvider.autoDispose<int>((ref) {
+  return ref
       .watch(transactionRepositoryProvider)
-      .getUncategorizedTransactions();
-  return transactions.length;
-});
-
-/// All categories for the category picker.
-final allCategoriesProvider = StreamProvider.autoDispose<List<Category>>((ref) {
-  return ref.watch(categoryRepositoryProvider).watchAllCategories();
-});
-
-/// Expense categories only.
-final expenseCategoriesProvider = StreamProvider.autoDispose<List<Category>>((ref) {
-  return ref.watch(categoryRepositoryProvider).watchExpenseCategories();
-});
-
-/// Income categories only.
-final incomeCategoriesProvider = StreamProvider.autoDispose<List<Category>>((ref) {
-  return ref.watch(categoryRepositoryProvider).watchIncomeCategories();
+      .getUncategorizedCount();
 });

--- a/lib/presentation/features/transactions/transactions_screen.dart
+++ b/lib/presentation/features/transactions/transactions_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../data/local/database/app_database.dart';
 import '../../shared/empty_states/empty_state_widget.dart';
 import '../../shared/loading/shimmer_loading.dart';
+import '../../shared/widgets/category_picker_sheet.dart';
 import '../accounts/accounts_providers.dart';
 import 'add_edit_transaction_screen.dart';
 import 'transactions_providers.dart';
@@ -116,13 +117,22 @@ class _TransactionsScreenState extends ConsumerState<TransactionsScreen> {
 }
 
 /// Transaction list grouped by date.
-class _TransactionListView extends StatelessWidget {
+class _TransactionListView extends ConsumerWidget {
   final List<Transaction> transactions;
 
   const _TransactionListView({required this.transactions});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Build category lookup map once at the list level
+    final categoriesAsync = ref.watch(allCategoriesProvider);
+    final categoryNames = <String, String>{};
+    categoriesAsync.whenData((categories) {
+      for (final c in categories) {
+        categoryNames[c.id] = c.name;
+      }
+    });
+
     // Group transactions by date
     final grouped = _groupByDate(transactions);
 
@@ -136,7 +146,12 @@ class _TransactionListView extends StatelessWidget {
           children: [
             _DateHeader(date: entry.key),
             for (final transaction in entry.value)
-              _TransactionTile(transaction: transaction),
+              _TransactionTile(
+                transaction: transaction,
+                categoryName: transaction.categoryId != null
+                    ? categoryNames[transaction.categoryId!]
+                    : null,
+              ),
           ],
         );
       },
@@ -174,27 +189,21 @@ class _DateHeader extends StatelessWidget {
   }
 }
 
-class _TransactionTile extends ConsumerWidget {
+class _TransactionTile extends StatelessWidget {
   final Transaction transaction;
+  final String? categoryName;
 
-  const _TransactionTile({required this.transaction});
+  const _TransactionTile({
+    required this.transaction,
+    this.categoryName,
+  });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final finance = theme.finance;
     final isIncome = transaction.amountCents > 0;
-    final categoriesAsync = ref.watch(allCategoriesProvider);
-
-    // Find category name
-    String? categoryName;
-    if (transaction.categoryId != null) {
-      categoriesAsync.whenData((categories) {
-        final cat = categories.where((c) => c.id == transaction.categoryId).firstOrNull;
-        if (cat != null) categoryName = cat.name;
-      });
-    }
 
     return ListTile(
       leading: CircleAvatar(
@@ -267,7 +276,7 @@ class _FilterBottomSheetState extends ConsumerState<_FilterBottomSheet> {
   final _minAmountController = TextEditingController();
   final _maxAmountController = TextEditingController();
 
-  // Cached names for display
+  // Display names resolved in initState
   String? _categoryName;
   String? _accountName;
 
@@ -281,6 +290,26 @@ class _FilterBottomSheetState extends ConsumerState<_FilterBottomSheet> {
     if (_filters.maxAmountCents != null) {
       _maxAmountController.text = _filters.maxAmountCents!.toCurrencyValue();
     }
+
+    // Resolve display names from IDs
+    _resolveCategoryName();
+    _resolveAccountName();
+  }
+
+  void _resolveCategoryName() {
+    if (_filters.categoryId == null) return;
+    ref.read(allCategoriesProvider).whenData((cats) {
+      final cat = cats.where((c) => c.id == _filters.categoryId).firstOrNull;
+      if (cat != null) setState(() => _categoryName = cat.name);
+    });
+  }
+
+  void _resolveAccountName() {
+    if (_filters.accountId == null) return;
+    ref.read(accountsProvider).whenData((accts) {
+      final acct = accts.where((a) => a.id == _filters.accountId).firstOrNull;
+      if (acct != null) setState(() => _accountName = acct.name);
+    });
   }
 
   @override
@@ -320,88 +349,27 @@ class _FilterBottomSheetState extends ConsumerState<_FilterBottomSheet> {
 
   void _showCategoryPicker() {
     final categoriesAsync = ref.read(allCategoriesProvider);
-    categoriesAsync.whenData((categories) {
-      final parents = categories.where((c) => c.parentId == null).toList();
-      showModalBottomSheet(
+    categoriesAsync.whenData((categories) async {
+      final result = await showCategoryPickerSheet(
         context: context,
-        isScrollControlled: true,
-        builder: (ctx) => DraggableScrollableSheet(
-          initialChildSize: 0.6,
-          minChildSize: 0.3,
-          maxChildSize: 0.9,
-          expand: false,
-          builder: (_, scrollController) => Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text('Filter by Category',
-                        style: Theme.of(ctx).textTheme.titleLarge),
-                    TextButton(
-                      onPressed: () {
-                        setState(() {
-                          _filters = _filters.copyWith(clearCategory: true);
-                          _categoryName = null;
-                        });
-                        Navigator.pop(ctx);
-                      },
-                      child: const Text('Clear'),
-                    ),
-                  ],
-                ),
-              ),
-              const Divider(height: 1),
-              Expanded(
-                child: ListView(
-                  controller: scrollController,
-                  children: [
-                    for (final parent in parents) ...[
-                      ListTile(
-                        leading: CircleAvatar(
-                          backgroundColor:
-                              Color(parent.color).withValues(alpha: 0.15),
-                          child: Icon(Icons.category,
-                              color: Color(parent.color), size: 20),
-                        ),
-                        title: Text(parent.name,
-                            style:
-                                const TextStyle(fontWeight: FontWeight.w600)),
-                        selected: _filters.categoryId == parent.id,
-                        onTap: () {
-                          setState(() {
-                            _filters =
-                                _filters.copyWith(categoryId: parent.id);
-                            _categoryName = parent.name;
-                          });
-                          Navigator.pop(ctx);
-                        },
-                      ),
-                      for (final child in categories
-                          .where((c) => c.parentId == parent.id))
-                        ListTile(
-                          contentPadding:
-                              const EdgeInsets.only(left: 56, right: 16),
-                          title: Text(child.name),
-                          selected: _filters.categoryId == child.id,
-                          onTap: () {
-                            setState(() {
-                              _filters =
-                                  _filters.copyWith(categoryId: child.id);
-                              _categoryName = child.name;
-                            });
-                            Navigator.pop(ctx);
-                          },
-                        ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
+        categories: categories,
+        selectedCategoryId: _filters.categoryId,
+        title: 'Filter by Category',
       );
+
+      if (!mounted) return;
+
+      if (result == null) {
+        setState(() {
+          _filters = _filters.copyWith(clearCategory: true);
+          _categoryName = null;
+        });
+      } else {
+        setState(() {
+          _filters = _filters.copyWith(categoryId: result.id);
+          _categoryName = result.name;
+        });
+      }
     });
   }
 
@@ -493,22 +461,6 @@ class _FilterBottomSheetState extends ConsumerState<_FilterBottomSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-
-    // Resolve names for display if we have IDs but no names yet
-    if (_filters.categoryId != null && _categoryName == null) {
-      ref.watch(allCategoriesProvider).whenData((cats) {
-        final cat =
-            cats.where((c) => c.id == _filters.categoryId).firstOrNull;
-        if (cat != null) _categoryName = cat.name;
-      });
-    }
-    if (_filters.accountId != null && _accountName == null) {
-      ref.watch(accountsProvider).whenData((accts) {
-        final acct =
-            accts.where((a) => a.id == _filters.accountId).firstOrNull;
-        if (acct != null) _accountName = acct.name;
-      });
-    }
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -652,4 +604,3 @@ class _FilterBottomSheetState extends ConsumerState<_FilterBottomSheet> {
     );
   }
 }
-

--- a/lib/presentation/shared/widgets/category_picker_sheet.dart
+++ b/lib/presentation/shared/widgets/category_picker_sheet.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/local/database/app_database.dart';
+
+/// Result returned when a category is selected.
+class CategoryPickerResult {
+  final String id;
+  final String name;
+
+  const CategoryPickerResult({required this.id, required this.name});
+}
+
+/// Shows a hierarchical category picker bottom sheet.
+///
+/// Returns the selected [CategoryPickerResult], or null if cleared/dismissed.
+Future<CategoryPickerResult?> showCategoryPickerSheet({
+  required BuildContext context,
+  required List<Category> categories,
+  String? selectedCategoryId,
+  String title = 'Select Category',
+  bool showClear = true,
+}) {
+  final parents = categories.where((c) => c.parentId == null).toList();
+
+  return showModalBottomSheet<CategoryPickerResult>(
+    context: context,
+    isScrollControlled: true,
+    builder: (ctx) => DraggableScrollableSheet(
+      initialChildSize: 0.6,
+      minChildSize: 0.3,
+      maxChildSize: 0.9,
+      expand: false,
+      builder: (_, scrollController) => Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(title, style: Theme.of(ctx).textTheme.titleLarge),
+                if (showClear && selectedCategoryId != null)
+                  TextButton(
+                    onPressed: () => Navigator.pop(ctx, null),
+                    child: const Text('Clear'),
+                  ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: ListView(
+              controller: scrollController,
+              children: [
+                for (final parent in parents) ...[
+                  ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor:
+                          Color(parent.color).withValues(alpha: 0.15),
+                      child: Icon(Icons.category,
+                          color: Color(parent.color), size: 20),
+                    ),
+                    title: Text(parent.name,
+                        style: const TextStyle(fontWeight: FontWeight.w600)),
+                    selected: selectedCategoryId == parent.id,
+                    onTap: () => Navigator.pop(
+                      ctx,
+                      CategoryPickerResult(id: parent.id, name: parent.name),
+                    ),
+                  ),
+                  for (final child
+                      in categories.where((c) => c.parentId == parent.id))
+                    ListTile(
+                      contentPadding:
+                          const EdgeInsets.only(left: 56, right: 16),
+                      title: Text(child.name),
+                      selected: selectedCategoryId == child.id,
+                      onTap: () => Navigator.pop(
+                        ctx,
+                        CategoryPickerResult(id: child.id, name: child.name),
+                      ),
+                    ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
- Move app-state providers (themeMode, appRouter, isUnlocked, lastPausedAt)
  from app.dart to core/di/providers.dart where they belong
- Move category stream providers to core/di/providers.dart since they're
  used across multiple features (transactions, budgets, dashboard)
- Extract AccountTypeInfo model to core/constants/account_types.dart
- Extract shared CategoryPickerSheet widget to eliminate duplicate
  category picker code between transaction and filter screens
- Fix ErrorHandler fallback using NetworkError for unknown errors;
  add UnexpectedError class for proper semantic typing
- Fix _FilterBottomSheet mutating state inside build(); resolve
  category/account names in initState() instead
- Fix _TransactionTile per-tile category lookup; build lookup map
  once at list level and pass names down
- Convert FutureProviders to StreamProviders for live reactivity
  (accountsByType, totalAssets, totalLiabilities, recentTransactions)
- Remove duplicate biometric enabled methods from PinService;
  BiometricService already owns this responsibility
- Add getUncategorizedCount() SQL COUNT query to avoid full table scan
- Replace hardcoded route strings in lock_screen.dart with AppRoutes

https://claude.ai/code/session_01CGvPgGcvr9xc5zFngHQNd8