### PR TITLE
Add budget management screens and providers

### DIFF
--- a/lib/presentation/features/budgets/add_edit_budget_screen.dart
+++ b/lib/presentation/features/budgets/add_edit_budget_screen.dart
@@ -1,0 +1,324 @@
+import 'package:drift/drift.dart' hide Column;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../core/extensions/money_extensions.dart';
+import '../../../data/local/database/app_database.dart';
+
+/// Add or edit a budget.
+class AddEditBudgetScreen extends ConsumerStatefulWidget {
+  final Budget? budget;
+
+  const AddEditBudgetScreen({super.key, this.budget});
+
+  @override
+  ConsumerState<AddEditBudgetScreen> createState() =>
+      _AddEditBudgetScreenState();
+}
+
+class _AddEditBudgetScreenState extends ConsumerState<AddEditBudgetScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountController = TextEditingController();
+  final _thresholdController = TextEditingController();
+
+  String? _selectedCategoryId;
+  String _periodType = 'monthly';
+  bool _rollover = false;
+  bool _isSaving = false;
+
+  bool get _isEditing => widget.budget != null;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_isEditing) {
+      final b = widget.budget!;
+      _amountController.text = b.amountCents.toCurrencyValue();
+      _thresholdController.text = (b.alertThreshold * 100).round().toString();
+      _selectedCategoryId = b.categoryId;
+      _periodType = b.periodType;
+      _rollover = b.rollover;
+    } else {
+      _thresholdController.text = '90';
+    }
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _thresholdController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    if (_selectedCategoryId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select a category')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+
+    try {
+      final repo = ref.read(budgetRepositoryProvider);
+      final amountCents = _amountController.text.toCents()!;
+      final threshold = (int.parse(_thresholdController.text)) / 100.0;
+      final now = DateTime.now().millisecondsSinceEpoch;
+
+      if (_isEditing) {
+        await repo.updateBudget(BudgetsCompanion(
+          id: Value(widget.budget!.id),
+          categoryId: Value(_selectedCategoryId!),
+          amountCents: Value(amountCents),
+          periodType: Value(_periodType),
+          rollover: Value(_rollover),
+          alertThreshold: Value(threshold),
+          updatedAt: Value(now),
+        ));
+      } else {
+        await repo.insertBudget(BudgetsCompanion.insert(
+          id: const Uuid().v4(),
+          categoryId: _selectedCategoryId!,
+          amountCents: amountCents,
+          periodType: _periodType,
+          startDate: now,
+          rollover: Value(_rollover),
+          alertThreshold: Value(threshold),
+          createdAt: now,
+          updatedAt: now,
+        ));
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_isEditing ? 'Budget updated' : 'Budget created'),
+          ),
+        );
+        Navigator.of(context).pop(true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  Future<void> _delete() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Budget'),
+        content: const Text(
+          'Are you sure you want to delete this budget? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() => _isSaving = true);
+    try {
+      await ref
+          .read(budgetRepositoryProvider)
+          .deleteBudget(widget.budget!.id);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Budget deleted')),
+        );
+        Navigator.of(context).pop(true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categoriesAsync = ref.watch(expenseCategoriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Edit Budget' : 'Add Budget'),
+        actions: [
+          if (_isEditing)
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete',
+              onPressed: _isSaving ? null : _delete,
+            ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Category picker
+            categoriesAsync.when(
+              loading: () => const LinearProgressIndicator(),
+              error: (e, _) => Text('Error loading categories: $e'),
+              data: (categories) {
+                return DropdownButtonFormField<String>(
+                  initialValue: _selectedCategoryId,
+                  decoration: const InputDecoration(
+                    labelText: 'Category *',
+                    filled: true,
+                  ),
+                  items: categories.map((c) {
+                    return DropdownMenuItem(
+                      value: c.id,
+                      child: Text(c.name),
+                    );
+                  }).toList(),
+                  onChanged: _isSaving
+                      ? null
+                      : (v) {
+                          if (v != null) {
+                            setState(() => _selectedCategoryId = v);
+                          }
+                        },
+                  validator: (v) => v == null ? 'Category is required' : null,
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Budget amount
+            TextFormField(
+              controller: _amountController,
+              decoration: const InputDecoration(
+                labelText: 'Budget Amount *',
+                hintText: '0.00',
+                prefixText: '\$ ',
+                filled: true,
+              ),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+              ],
+              enabled: !_isSaving,
+              validator: (v) {
+                if (v == null || v.trim().isEmpty) return 'Amount is required';
+                if (v.toCents() == null || v.toCents()! <= 0) {
+                  return 'Enter a valid positive amount';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Period type
+            DropdownButtonFormField<String>(
+              initialValue: _periodType,
+              decoration: const InputDecoration(
+                labelText: 'Period *',
+                filled: true,
+              ),
+              items: const [
+                DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
+                DropdownMenuItem(value: 'annual', child: Text('Annual')),
+              ],
+              onChanged: _isSaving
+                  ? null
+                  : (v) {
+                      if (v != null) setState(() => _periodType = v);
+                    },
+            ),
+            const SizedBox(height: 16),
+
+            // Rollover toggle
+            SwitchListTile(
+              title: const Text('Rollover unused budget'),
+              subtitle: const Text(
+                'Carry unspent amounts into the next period',
+              ),
+              value: _rollover,
+              onChanged:
+                  _isSaving ? null : (v) => setState(() => _rollover = v),
+              contentPadding: EdgeInsets.zero,
+            ),
+            const SizedBox(height: 8),
+
+            // Alert threshold
+            TextFormField(
+              controller: _thresholdController,
+              decoration: const InputDecoration(
+                labelText: 'Alert Threshold (%)',
+                hintText: '90',
+                suffixText: '%',
+                filled: true,
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+              ],
+              enabled: !_isSaving,
+              validator: (v) {
+                if (v == null || v.trim().isEmpty) return null;
+                final val = int.tryParse(v);
+                if (val == null || val < 1 || val > 100) {
+                  return 'Enter a value between 1 and 100';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                'You will be alerted when spending reaches this percentage of your budget.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+            const SizedBox(height: 32),
+
+            // Save button
+            FilledButton(
+              onPressed: _isSaving ? null : _save,
+              child: _isSaving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(_isEditing ? 'Save Changes' : 'Create Budget'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/budgets/budgets_providers.dart
+++ b/lib/presentation/features/budgets/budgets_providers.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../core/extensions/money_extensions.dart';
+import '../../../data/local/database/app_database.dart';
+
+/// Watch all active budgets.
+final budgetsProvider = StreamProvider.autoDispose<List<Budget>>((ref) {
+  return ref.watch(budgetRepositoryProvider).watchActiveBudgets();
+});
+
+/// Get a single budget by ID.
+final budgetByIdProvider =
+    FutureProvider.autoDispose.family<Budget?, String>((ref, id) {
+  return ref.watch(budgetRepositoryProvider).getBudgetById(id);
+});
+
+/// Budget with calculated spending data for the current period.
+class BudgetWithSpent {
+  final Budget budget;
+  final int spentCents;
+  final double percentage;
+
+  const BudgetWithSpent({
+    required this.budget,
+    required this.spentCents,
+    required this.percentage,
+  });
+}
+
+/// Provides a list of budgets with their current-period spending amounts.
+///
+/// For monthly budgets, the period is the current calendar month.
+/// For annual budgets, the period is the current calendar year.
+/// Expenses are stored as negative cents, so we sum and negate to get a
+/// positive "spent" value.
+final budgetsWithSpentProvider =
+    FutureProvider.autoDispose<List<BudgetWithSpent>>((ref) async {
+  final budgets = await ref.watch(budgetsProvider.future);
+  final transactionRepo = ref.watch(transactionRepositoryProvider);
+
+  final now = DateTime.now();
+  final monthStart = now.startOfMonth.millisecondsSinceEpoch;
+  final monthEnd = now.endOfMonth.millisecondsSinceEpoch;
+  final yearStart = DateTime(now.year, 1, 1).millisecondsSinceEpoch;
+  final yearEnd =
+      DateTime(now.year, 12, 31, 23, 59, 59, 999).millisecondsSinceEpoch;
+
+  final results = <BudgetWithSpent>[];
+
+  for (final budget in budgets) {
+    final isMonthly = budget.periodType == 'monthly';
+    final start = isMonthly ? monthStart : yearStart;
+    final end = isMonthly ? monthEnd : yearEnd;
+
+    final transactions = await transactionRepo.getTransactionsByDateRange(
+      start,
+      end,
+      categoryId: budget.categoryId,
+    );
+
+    // Sum negative (expense) transactions and take absolute value.
+    final spentCents = transactions
+        .where((t) => t.amountCents < 0)
+        .fold<int>(0, (sum, t) => sum + t.amountCents)
+        .abs();
+
+    final percentage =
+        budget.amountCents > 0 ? spentCents.toDouble() / budget.amountCents : 0.0;
+
+    results.add(BudgetWithSpent(
+      budget: budget,
+      spentCents: spentCents,
+      percentage: percentage,
+    ));
+  }
+
+  return results;
+});

--- a/lib/presentation/features/budgets/budgets_screen.dart
+++ b/lib/presentation/features/budgets/budgets_screen.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../core/extensions/money_extensions.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../data/local/database/app_database.dart';
+import '../../shared/empty_states/empty_state_widget.dart';
+import '../../shared/loading/shimmer_loading.dart';
+import 'add_edit_budget_screen.dart';
+import 'budgets_providers.dart';
+
+/// Budget list screen with summary card and per-budget progress bars.
+class BudgetsScreen extends ConsumerWidget {
+  const BudgetsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final budgetsAsync = ref.watch(budgetsWithSpentProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Budgets'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add budget',
+            onPressed: () => _navigateToAddBudget(context),
+          ),
+        ],
+      ),
+      body: budgetsAsync.when(
+        loading: () => const ShimmerTransactionList(itemCount: 5),
+        error: (error, _) => Center(child: Text('Error: $error')),
+        data: (budgets) {
+          if (budgets.isEmpty) {
+            return EmptyStateWidget(
+              icon: Icons.pie_chart_outline,
+              title: 'No budgets yet',
+              description:
+                  'Create budgets to track your spending by category and stay on top of your finances.',
+              actionLabel: 'Add Budget',
+              onAction: () => _navigateToAddBudget(context),
+            );
+          }
+          return _BudgetsListView(budgets: budgets);
+        },
+      ),
+    );
+  }
+
+  void _navigateToAddBudget(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => const AddEditBudgetScreen(),
+      ),
+    );
+  }
+}
+
+/// List view with summary header and individual budget items.
+class _BudgetsListView extends ConsumerWidget {
+  final List<BudgetWithSpent> budgets;
+
+  const _BudgetsListView({required this.budgets});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesAsync = ref.watch(allCategoriesProvider);
+    final categoryMap = categoriesAsync.whenData((cats) {
+      return {for (final c in cats) c.id: c};
+    });
+
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 80),
+      children: [
+        _SummaryCard(budgets: budgets),
+        const SizedBox(height: 8),
+        for (final item in budgets)
+          _BudgetTile(
+            item: item,
+            category: categoryMap.valueOrNull?[item.budget.categoryId],
+          ),
+      ],
+    );
+  }
+}
+
+/// Summary card showing total budgeted vs total spent this month.
+class _SummaryCard extends StatelessWidget {
+  final List<BudgetWithSpent> budgets;
+
+  const _SummaryCard({required this.budgets});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final finance = theme.finance;
+
+    final totalBudgeted =
+        budgets.fold<int>(0, (sum, b) => sum + b.budget.amountCents);
+    final totalSpent = budgets.fold<int>(0, (sum, b) => sum + b.spentCents);
+    final overallPercentage =
+        totalBudgeted > 0 ? totalSpent.toDouble() / totalBudgeted : 0.0;
+    final progressColor = _budgetColor(finance, overallPercentage);
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Monthly Overview',
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Budgeted',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant)),
+                      Text(
+                        totalBudgeted.toCurrency(),
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Spent',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant)),
+                      Text(
+                        totalSpent.toCurrency(),
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: progressColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Remaining',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant)),
+                      Text(
+                        (totalBudgeted - totalSpent).toCurrency(),
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: progressColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: overallPercentage.clamp(0.0, 1.0),
+                backgroundColor: colorScheme.surfaceContainerHighest,
+                color: progressColor,
+                minHeight: 6,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Single budget list item with category name, amounts, and progress bar.
+class _BudgetTile extends StatelessWidget {
+  final BudgetWithSpent item;
+  final Category? category;
+
+  const _BudgetTile({required this.item, this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final finance = theme.finance;
+    final progressColor = _budgetColor(finance, item.percentage);
+    final remaining = item.budget.amountCents - item.spentCents;
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: category != null
+            ? Color(category!.color).withValues(alpha: 0.15)
+            : colorScheme.primaryContainer,
+        child: Icon(
+          Icons.pie_chart_outline,
+          color: category != null
+              ? Color(category!.color)
+              : colorScheme.primary,
+          size: 20,
+        ),
+      ),
+      title: Text(
+        category?.name ?? 'Unknown Category',
+        style: theme.textTheme.bodyLarge?.copyWith(
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: item.percentage.clamp(0.0, 1.0),
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              color: progressColor,
+              minHeight: 4,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${item.spentCents.toCurrency()} of ${item.budget.amountCents.toCurrency()}'
+            ' ${remaining >= 0 ? '(${remaining.toCurrency()} left)' : '(${remaining.abs().toCurrency()} over)'}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: progressColor,
+            ),
+          ),
+        ],
+      ),
+      trailing: Text(
+        item.budget.periodType == 'monthly' ? 'Monthly' : 'Annual',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+        ),
+      ),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => AddEditBudgetScreen(budget: item.budget),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Returns the appropriate budget color based on spending percentage.
+/// On track: < 75%, Warning: 75-100%, Over: > 100%.
+Color _budgetColor(FinanceColors finance, double percentage) {
+  if (percentage > 1.0) return finance.budgetOver;
+  if (percentage >= 0.75) return finance.budgetWarning;
+  return finance.budgetOnTrack;
+}


### PR DESCRIPTION
## Summary
- Add budget providers (list, CRUD operations) in budgets_providers.dart
- Add budget list screen with progress bars and period filtering
- Add budget add/edit form with category picker and amount input

## Test plan
- [x] `flutter analyze` passes (pre-existing info only)
- [x] `flutter test` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)