### PR TITLE
Fix cascade deletion and data correctness issues

### DIFF
--- a/lib/domain/usecases/import/csv_import_service.dart
+++ b/lib/domain/usecases/import/csv_import_service.dart
@@ -308,7 +308,7 @@ class CsvImportService {
       fileName: preview.fileName,
       rowCount: preview.totalRows,
       importedCount: importedCount,
-      skippedCount: skippedCount + preview.errors.length,
+      skippedCount: skippedCount,
       status: status,
       errorMessage: errorMessage != null ? Value(errorMessage) : const Value(null),
       createdAt: now,


### PR DESCRIPTION
## Summary
- **Account deletion cascade**: `deleteAccount()` now also removes recurring transactions, investment holdings, and nulls out `goals.linkedAccountId` and `transactions.transferAccountId` — previously these were orphaned
- **Category deletion cascade**: `deleteCategory()` now handles children, nulls `categoryId` on transactions/recurring, deletes associated budgets, then removes categories
- **Import skip count**: DB record no longer double-counts errors as skipped (errors tracked separately via status field)
- **Recurring date math**: Replaced fixed-day calculation (`monthly=30d`) with calendar-aware `DateTime` arithmetic with end-of-month clamping (e.g., Jan 31 + 1 month → Feb 28)

## Files changed
- `lib/data/repositories/account_repository.dart`
- `lib/data/repositories/category_repository.dart`
- `lib/domain/usecases/import/csv_import_service.dart`
- `lib/domain/usecases/recurring/recurring_detection_service.dart`

## Test plan
- [ ] Verify `flutter analyze` passes
- [ ] Verify `flutter test` passes (31 existing tests)
- [ ] Manual: create account with transactions → delete account → verify no orphaned recurring/holdings/goals
- [ ] Manual: create parent category with children linked to budgets → delete parent → verify cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)