### PR TITLE
Wire routes for budgets, goals, recurring, and CSV import

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -10,6 +10,11 @@ import '../../presentation/features/onboarding/onboarding_screen.dart';
 import '../../presentation/features/transactions/transactions_screen.dart';
 import '../../presentation/features/ai_assistant/ai_assistant_screen.dart';
 import '../../presentation/features/settings/settings_screen.dart';
+import '../../presentation/features/budgets/budgets_screen.dart';
+import '../../presentation/features/goals/goals_screen.dart';
+import '../../presentation/features/recurring/recurring_screen.dart';
+import '../../presentation/features/import/csv_import_screen.dart';
+import '../../presentation/features/import/import_history_screen.dart';
 import '../../presentation/shared/widgets/app_shell.dart';
 import '../di/providers.dart';
 
@@ -26,6 +31,11 @@ class AppRoutes {
   static const String aiAssistant = '/ai';
   static const String settings = '/settings';
   static const String onboarding = '/onboarding';
+  static const String budgets = '/budgets';
+  static const String goals = '/goals';
+  static const String recurring = '/recurring';
+  static const String csvImport = '/import/csv';
+  static const String importHistory = '/import/history';
 }
 
 /// Navigator keys for each tab branch.
@@ -88,6 +98,41 @@ GoRouter createAppRouter(Ref ref) {
         path: AppRoutes.onboarding,
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) => const OnboardingScreen(),
+      ),
+
+      // Budgets (full-screen)
+      GoRoute(
+        path: AppRoutes.budgets,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const BudgetsScreen(),
+      ),
+
+      // Goals (full-screen)
+      GoRoute(
+        path: AppRoutes.goals,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const GoalsScreen(),
+      ),
+
+      // Recurring transactions (full-screen)
+      GoRoute(
+        path: AppRoutes.recurring,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const RecurringScreen(),
+      ),
+
+      // CSV import (full-screen)
+      GoRoute(
+        path: AppRoutes.csvImport,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const CsvImportScreen(),
+      ),
+
+      // Import history (full-screen)
+      GoRoute(
+        path: AppRoutes.importHistory,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const ImportHistoryScreen(),
       ),
 
       // Main app with bottom navigation

--- a/lib/presentation/features/budgets/budgets_screen.dart
+++ b/lib/presentation/features/budgets/budgets_screen.dart
@@ -25,7 +25,7 @@ class BudgetsScreen extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: 'Add budget',
-            onPressed: () => _navigateToAddBudget(context),
+            onPressed: () => _navigateToAddBudget(context, ref),
           ),
         ],
       ),
@@ -40,7 +40,7 @@ class BudgetsScreen extends ConsumerWidget {
               description:
                   'Create budgets to track your spending by category and stay on top of your finances.',
               actionLabel: 'Add Budget',
-              onAction: () => _navigateToAddBudget(context),
+              onAction: () => _navigateToAddBudget(context, ref),
             );
           }
           return _BudgetsListView(budgets: budgets);
@@ -49,12 +49,15 @@ class BudgetsScreen extends ConsumerWidget {
     );
   }
 
-  void _navigateToAddBudget(BuildContext context) {
-    Navigator.of(context).push(
+  Future<void> _navigateToAddBudget(BuildContext context, WidgetRef ref) async {
+    final result = await Navigator.of(context).push<bool>(
       MaterialPageRoute(
         builder: (_) => const AddEditBudgetScreen(),
       ),
     );
+    if (result == true) {
+      ref.invalidate(budgetsWithSpentProvider);
+    }
   }
 }
 
@@ -191,14 +194,14 @@ class _SummaryCard extends StatelessWidget {
 }
 
 /// Single budget list item with category name, amounts, and progress bar.
-class _BudgetTile extends StatelessWidget {
+class _BudgetTile extends ConsumerWidget {
   final BudgetWithSpent item;
   final Category? category;
 
   const _BudgetTile({required this.item, this.category});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final finance = theme.finance;
@@ -253,12 +256,15 @@ class _BudgetTile extends StatelessWidget {
           color: colorScheme.onSurfaceVariant,
         ),
       ),
-      onTap: () {
-        Navigator.of(context).push(
+      onTap: () async {
+        final result = await Navigator.of(context).push<bool>(
           MaterialPageRoute(
             builder: (_) => AddEditBudgetScreen(budget: item.budget),
           ),
         );
+        if (result == true) {
+          ref.invalidate(budgetsWithSpentProvider);
+        }
       },
     );
   }

--- a/lib/presentation/features/dashboard/dashboard_screen.dart
+++ b/lib/presentation/features/dashboard/dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/router/app_router.dart';
 import '../../../core/extensions/money_extensions.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../data/local/database/app_database.dart';
@@ -284,7 +285,7 @@ class _BudgetHealthCard extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () {
-                    // Budgets not yet implemented
+                    context.push(AppRoutes.budgets);
                   },
                   child: const Text('See all'),
                 ),

--- a/lib/presentation/features/settings/settings_screen.dart
+++ b/lib/presentation/features/settings/settings_screen.dart
@@ -51,6 +51,32 @@ class SettingsScreen extends ConsumerWidget {
 
           const Divider(),
 
+          // Financial Planning
+          const _SectionHeader(title: 'Financial Planning'),
+          ListTile(
+            leading: const Icon(Icons.pie_chart_outline),
+            title: const Text('Budgets'),
+            subtitle: const Text('Track spending by category'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.budgets),
+          ),
+          ListTile(
+            leading: const Icon(Icons.flag_outlined),
+            title: const Text('Goals'),
+            subtitle: const Text('Savings and debt payoff targets'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.goals),
+          ),
+          ListTile(
+            leading: const Icon(Icons.repeat),
+            title: const Text('Recurring Transactions'),
+            subtitle: const Text('Subscriptions and regular payments'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.recurring),
+          ),
+
+          const Divider(),
+
           // Categories
           const _SectionHeader(title: 'Categories & Rules'),
           ListTile(
@@ -149,9 +175,7 @@ class SettingsScreen extends ConsumerWidget {
             title: const Text('Import Data'),
             subtitle: const Text('CSV, Mint, YNAB, Monarch'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {
-              _showComingSoon(context, 'Data import');
-            },
+            onTap: () => context.push(AppRoutes.csvImport),
           ),
           ListTile(
             leading: const Icon(Icons.file_download),


### PR DESCRIPTION
## Summary
- **5 new routes**: `/budgets`, `/goals`, `/recurring`, `/import/csv`, `/import/history` with full-screen `GoRoute` entries
- **Dashboard**: Budget "See all" button now navigates to budgets screen (was a no-op comment)
- **Settings**: New "Financial Planning" section with tiles for Budgets, Goals, Recurring; Import Data tile now navigates to CSV import (was "coming soon")
- **Budget invalidation**: `BudgetsScreen` and `_BudgetTile` now invalidate `budgetsWithSpentProvider` after returning from add/edit, so the list refreshes immediately

## Files changed
- `lib/core/router/app_router.dart`
- `lib/presentation/features/dashboard/dashboard_screen.dart`
- `lib/presentation/features/settings/settings_screen.dart`
- `lib/presentation/features/budgets/budgets_screen.dart`

## Test plan
- [ ] Verify `flutter analyze` passes
- [ ] Verify `flutter test` passes (31 existing tests)
- [ ] Manual: navigate to each new screen from settings (budgets, goals, recurring, import)
- [ ] Manual: tap "See all" on dashboard budget card → navigates to budgets screen
- [ ] Manual: add a budget → return to list → new budget appears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)