### PR TITLE
Harden Android security and tighten code quality

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,7 +21,9 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    avoid_print: true
+    always_declare_return_types: true
+    prefer_const_constructors: true
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Flutter and plugin keep rules for release builds with minification.
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+-keep class com.patrimonium.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="patrimonium"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/domain/usecases/auth/biometric_service.dart
+++ b/lib/domain/usecases/auth/biometric_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:local_auth/local_auth.dart';
 
 import '../../../data/local/secure_storage/secure_storage_service.dart';
@@ -53,8 +54,8 @@ class BiometricService {
           biometricOnly: true,
         ),
       );
-    } catch (_) {
-      // Authentication failed or was cancelled
+    } catch (e) {
+      if (kDebugMode) debugPrint('Biometric auth failed: $e');
       return false;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -16,7 +17,11 @@ Future<void> main() async {
   // Seed default categories if this is a fresh install
   final categoryRepo = CategoryRepository(database);
   final seeder = CategorySeeder(categoryRepo);
-  await seeder.seedIfEmpty();
+  try {
+    await seeder.seedIfEmpty();
+  } catch (e) {
+    if (kDebugMode) debugPrint('Category seeding failed: $e');
+  }
 
   // TODO: Initialize Sentry
   // await SentryFlutter.init(


### PR DESCRIPTION
## Summary
- **Android security**: Add `android:usesCleartextTraffic="false"` to block plaintext HTTP
- **ProGuard rules**: New `proguard-rules.pro` with Flutter keep rules for release minification
- **Biometric logging**: Replace silent `catch (_)` with `kDebugMode`-guarded `debugPrint` for debuggability
- **Seeder resilience**: Wrap `seedIfEmpty()` in try/catch so a seeding failure doesn't crash app startup
- **Lint rules**: Enable `avoid_print`, `always_declare_return_types`, `prefer_const_constructors`

## Files changed
- `android/app/src/main/AndroidManifest.xml`
- `android/app/proguard-rules.pro` (new)
- `lib/domain/usecases/auth/biometric_service.dart`
- `lib/main.dart`
- `analysis_options.yaml`

## Test plan
- [ ] Verify `flutter analyze` passes (2 pre-existing info-level const warnings in settings_screen.dart)
- [ ] Verify `flutter test` passes (31 existing tests)
- [ ] Verify ProGuard file exists at correct path for future release builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)