### PR TITLE
Add SimpleFIN API client, sync service, and data layer

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -19,6 +19,8 @@ class AppConstants {
   static const int minSyncIntervalMinutes = 15;
   static const int syncTimeoutSeconds = 60;
   static const int maxConsecutiveSyncFailures = 3;
+  static const int maxDailySyncs = 24;
+  static const int backgroundSyncIntervalHours = 8;
 
   /// LLM rate limits.
   static const int maxAutomatedInsightsPerHour = 20;

--- a/lib/core/error/app_error.dart
+++ b/lib/core/error/app_error.dart
@@ -104,6 +104,14 @@ class BankSyncError extends AppError {
   factory BankSyncError.circuitOpen() => const BankSyncError(
         message: 'Bank sync is temporarily paused due to repeated failures. Will retry automatically.',
       );
+
+  factory BankSyncError.paymentRequired() => const BankSyncError(
+        message: 'SimpleFIN subscription payment required. Please check your account at simplefin.org.',
+      );
+
+  factory BankSyncError.tokenCompromised() => const BankSyncError(
+        message: 'Setup token already claimed or compromised. Please generate a new token from simplefin.org.',
+      );
 }
 
 /// LLM/AI-related errors.

--- a/lib/data/remote/dio_client.dart
+++ b/lib/data/remote/dio_client.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// Creates a configured Dio instance for HTTP requests.
+///
+/// Conservative timeouts for SimpleFIN's rate-limited API.
+/// No retry interceptor — retries are dangerous with 24 req/day limit.
+Dio createDioClient() {
+  final dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 5),
+    ),
+  );
+
+  if (kDebugMode) {
+    dio.interceptors.add(LogInterceptor(
+      requestBody: true,
+      responseBody: true,
+    ));
+  }
+
+  return dio;
+}

--- a/lib/data/remote/simplefin/simplefin_client.dart
+++ b/lib/data/remote/simplefin/simplefin_client.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import 'simplefin_models.dart';
+
+/// Client for the SimpleFIN Bridge protocol.
+///
+/// Handles token claiming and account/transaction fetching.
+/// See: https://beta-bridge.simplefin.org/info/developers
+class SimplefinClient {
+  SimplefinClient(this._dio);
+
+  final Dio _dio;
+
+  /// Claim a setup token and receive an access URL.
+  ///
+  /// The [base64Token] is obtained from simplefin.org by the user.
+  /// Returns a [SimplefinAccessUrl] containing credentials for future API calls.
+  ///
+  /// Throws [SimplefinApiException] on failure:
+  /// - 403: Token already claimed or compromised
+  Future<SimplefinAccessUrl> claimSetupToken(String base64Token) async {
+    final String claimUrl;
+    try {
+      claimUrl = utf8.decode(base64.decode(base64Token.trim()));
+    } on FormatException {
+      throw const SimplefinApiException(
+        statusCode: 0,
+        message: 'Invalid setup token format. '
+            'Please copy the entire token from simplefin.org.',
+      );
+    }
+
+    try {
+      final response = await _dio.post<String>(
+        claimUrl,
+        options: Options(
+          responseType: ResponseType.plain,
+        ),
+      );
+
+      final accessUrlString = response.data?.trim();
+      if (accessUrlString == null || accessUrlString.isEmpty) {
+        throw const SimplefinApiException(
+          statusCode: 0,
+          message: 'Empty response from claim URL',
+        );
+      }
+
+      return SimplefinAccessUrl.parse(accessUrlString);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 403) {
+        throw const SimplefinApiException(
+          statusCode: 403,
+          message: 'Token already claimed or compromised. '
+              'Please generate a new setup token from simplefin.org.',
+        );
+      }
+      throw SimplefinApiException(
+        statusCode: e.response?.statusCode ?? 0,
+        message: e.message ?? 'Failed to claim setup token',
+      );
+    }
+  }
+
+  /// Fetch accounts and optionally transactions from SimpleFIN.
+  ///
+  /// [accessUrl] is the parsed access URL from [claimSetupToken].
+  /// [startDate] filters transactions to those posted after this unix timestamp.
+  /// [endDate] filters transactions to those posted before this unix timestamp.
+  /// [includePending] includes pending transactions if true.
+  /// [balancesOnly] skips transaction data if true (faster, lighter).
+  ///
+  /// Throws [SimplefinApiException] on failure:
+  /// - 402: SimpleFIN subscription payment required
+  /// - 403: Access revoked, need to re-authenticate
+  Future<SimplefinAccountsResponse> getAccounts(
+    SimplefinAccessUrl accessUrl, {
+    int? startDate,
+    int? endDate,
+    bool? includePending,
+    bool balancesOnly = false,
+  }) async {
+    final queryParams = <String, dynamic>{};
+    if (startDate != null) queryParams['start-date'] = startDate;
+    if (endDate != null) queryParams['end-date'] = endDate;
+    if (includePending == true) queryParams['pending'] = 1;
+    if (balancesOnly) queryParams['balances-only'] = 1;
+
+    final credentials = base64.encode(
+      utf8.encode('${accessUrl.username}:${accessUrl.password}'),
+    );
+
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '${accessUrl.baseUrl}/accounts',
+        queryParameters: queryParams.isNotEmpty ? queryParams : null,
+        options: Options(
+          headers: {'Authorization': 'Basic $credentials'},
+        ),
+      );
+
+      if (response.data == null) {
+        throw const SimplefinApiException(
+          statusCode: 0,
+          message: 'Empty response from SimpleFIN',
+        );
+      }
+
+      return SimplefinAccountsResponse.fromJson(response.data!);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 402) {
+        throw const SimplefinApiException(
+          statusCode: 402,
+          message: 'SimpleFIN subscription payment required. '
+              'Please check your account at simplefin.org.',
+        );
+      }
+      if (e.response?.statusCode == 403) {
+        throw const SimplefinApiException(
+          statusCode: 403,
+          message: 'Access has been revoked. '
+              'Please reconnect your account.',
+        );
+      }
+      throw SimplefinApiException(
+        statusCode: e.response?.statusCode ?? 0,
+        message: e.message ?? 'Failed to fetch accounts',
+      );
+    }
+  }
+}

--- a/lib/data/remote/simplefin/simplefin_models.dart
+++ b/lib/data/remote/simplefin/simplefin_models.dart
@@ -1,0 +1,160 @@
+/// Parsed SimpleFIN access URL containing credentials and endpoint.
+class SimplefinAccessUrl {
+  final String scheme;
+  final String username;
+  final String password;
+  final String host;
+  final String path;
+
+  const SimplefinAccessUrl({
+    required this.scheme,
+    required this.username,
+    required this.password,
+    required this.host,
+    required this.path,
+  });
+
+  /// Base URL for API calls (without credentials).
+  String get baseUrl => '$scheme://$host$path';
+
+  /// Full URL including credentials (for storage).
+  @override
+  String toString() => '$scheme://$username:$password@$host$path';
+
+  /// Parse from a full access URL string.
+  factory SimplefinAccessUrl.parse(String url) {
+    final uri = Uri.parse(url);
+    return SimplefinAccessUrl(
+      scheme: uri.scheme,
+      username: uri.userInfo.split(':').first,
+      password: uri.userInfo.contains(':')
+          ? uri.userInfo.substring(uri.userInfo.indexOf(':') + 1)
+          : '',
+      host: uri.host + (uri.hasPort ? ':${uri.port}' : ''),
+      path: uri.path,
+    );
+  }
+}
+
+/// A single account returned by SimpleFIN.
+class SimplefinAccount {
+  final String id;
+  final String name;
+  final String? orgName;
+  final String? orgDomain;
+  final String currency;
+  final int balanceCents;
+  final int? availableBalanceCents;
+  final int balanceDateUnix;
+  final List<SimplefinTransaction> transactions;
+
+  const SimplefinAccount({
+    required this.id,
+    required this.name,
+    this.orgName,
+    this.orgDomain,
+    required this.currency,
+    required this.balanceCents,
+    this.availableBalanceCents,
+    required this.balanceDateUnix,
+    this.transactions = const [],
+  });
+
+  /// Parse from SimpleFIN JSON response.
+  factory SimplefinAccount.fromJson(Map<String, dynamic> json) {
+    final org = json['org'] as Map<String, dynamic>?;
+    return SimplefinAccount(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      orgName: org?['name'] as String?,
+      orgDomain: org?['domain'] as String?,
+      currency: (json['currency'] as String?) ?? 'USD',
+      balanceCents: _amountToCents(json['balance'] as String),
+      availableBalanceCents: json['available'] != null
+          ? _amountToCents(json['available'] as String)
+          : null,
+      balanceDateUnix: json['balance-date'] as int,
+      transactions: (json['transactions'] as List<dynamic>?)
+              ?.map((t) =>
+                  SimplefinTransaction.fromJson(t as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+  }
+}
+
+/// A single transaction returned by SimpleFIN.
+class SimplefinTransaction {
+  final String id;
+  final int postedUnix;
+  final int amountCents;
+  final String description;
+  final int? transactedAtUnix;
+  final bool isPending;
+
+  const SimplefinTransaction({
+    required this.id,
+    required this.postedUnix,
+    required this.amountCents,
+    required this.description,
+    this.transactedAtUnix,
+    this.isPending = false,
+  });
+
+  /// Parse from SimpleFIN JSON response.
+  factory SimplefinTransaction.fromJson(Map<String, dynamic> json) {
+    return SimplefinTransaction(
+      id: json['id'] as String,
+      postedUnix: json['posted'] as int,
+      amountCents: _amountToCents(json['amount'] as String),
+      description: json['description'] as String? ?? '',
+      transactedAtUnix: json['transacted_at'] as int?,
+      isPending: json['pending'] as bool? ?? false,
+    );
+  }
+}
+
+/// Top-level response from GET /accounts.
+class SimplefinAccountsResponse {
+  final List<String> errors;
+  final List<SimplefinAccount> accounts;
+
+  const SimplefinAccountsResponse({
+    this.errors = const [],
+    this.accounts = const [],
+  });
+
+  /// Parse from SimpleFIN JSON response.
+  factory SimplefinAccountsResponse.fromJson(Map<String, dynamic> json) {
+    return SimplefinAccountsResponse(
+      errors: (json['errors'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      accounts: (json['accounts'] as List<dynamic>?)
+              ?.map(
+                  (a) => SimplefinAccount.fromJson(a as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+  }
+}
+
+/// Exception thrown by SimpleFIN API calls.
+class SimplefinApiException implements Exception {
+  final int statusCode;
+  final String message;
+
+  const SimplefinApiException({
+    required this.statusCode,
+    required this.message,
+  });
+
+  @override
+  String toString() => 'SimplefinApiException($statusCode): $message';
+}
+
+/// Parse a SimpleFIN amount string (e.g., "-123.45") to integer cents.
+int _amountToCents(String amount) {
+  return (double.parse(amount) * 100).round();
+}

--- a/lib/data/repositories/account_repository.dart
+++ b/lib/data/repositories/account_repository.dart
@@ -145,6 +145,50 @@ class AccountRepository {
     });
   }
 
+  /// Link an account to a bank connection.
+  Future<void> linkToBank(
+    String accountId,
+    String bankConnectionId,
+    String externalId,
+  ) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return (_db.update(_db.accounts)..where((a) => a.id.equals(accountId)))
+        .write(AccountsCompanion(
+      bankConnectionId: Value(bankConnectionId),
+      externalId: Value(externalId),
+      lastSyncedAt: Value(now),
+      updatedAt: Value(now),
+    ));
+  }
+
+  /// Unlink an account from its bank connection.
+  Future<void> unlinkFromBank(String accountId) {
+    return (_db.update(_db.accounts)..where((a) => a.id.equals(accountId)))
+        .write(AccountsCompanion(
+      bankConnectionId: const Value(null),
+      externalId: const Value(null),
+      lastSyncedAt: const Value(null),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  /// Get all accounts linked to a specific bank connection.
+  Future<List<Account>> getAccountsByConnection(String bankConnectionId) {
+    return (_db.select(_db.accounts)
+          ..where((a) => a.bankConnectionId.equals(bankConnectionId))
+          ..orderBy([(a) => OrderingTerm.asc(a.displayOrder)]))
+        .get();
+  }
+
+  /// Update the last synced timestamp for an account.
+  Future<void> updateLastSyncedAt(String accountId) {
+    return (_db.update(_db.accounts)..where((a) => a.id.equals(accountId)))
+        .write(AccountsCompanion(
+      lastSyncedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
   /// Get count of accounts.
   Future<int> getAccountCount() async {
     final count = _db.accounts.id.count();

--- a/lib/data/repositories/bank_connection_repository.dart
+++ b/lib/data/repositories/bank_connection_repository.dart
@@ -1,0 +1,92 @@
+import 'package:drift/drift.dart';
+
+import '../local/database/app_database.dart';
+
+/// Repository for bank connection CRUD operations.
+class BankConnectionRepository {
+  BankConnectionRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// Watch all bank connections ordered by creation date.
+  Stream<List<BankConnection>> watchAllConnections() {
+    return (_db.select(_db.bankConnections)
+          ..orderBy([(c) => OrderingTerm.desc(c.createdAt)]))
+        .watch();
+  }
+
+  /// Get all connections (one-shot).
+  Future<List<BankConnection>> getAllConnections() {
+    return (_db.select(_db.bankConnections)
+          ..orderBy([(c) => OrderingTerm.desc(c.createdAt)]))
+        .get();
+  }
+
+  /// Get a single connection by ID.
+  Future<BankConnection?> getConnectionById(String id) {
+    return (_db.select(_db.bankConnections)
+          ..where((c) => c.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  /// Watch a single connection by ID.
+  Stream<BankConnection?> watchConnectionById(String id) {
+    return (_db.select(_db.bankConnections)
+          ..where((c) => c.id.equals(id)))
+        .watchSingleOrNull();
+  }
+
+  /// Insert a new connection.
+  Future<void> insertConnection(BankConnectionsCompanion connection) {
+    return _db.into(_db.bankConnections).insert(connection);
+  }
+
+  /// Update an existing connection.
+  Future<bool> updateConnection(BankConnectionsCompanion connection) {
+    return (_db.update(_db.bankConnections)
+          ..where((c) => c.id.equals(connection.id.value)))
+        .write(connection)
+        .then((rows) => rows > 0);
+  }
+
+  /// Update connection status and optional error message.
+  Future<void> updateStatus(
+    String id,
+    String status, {
+    String? errorMessage,
+  }) {
+    return (_db.update(_db.bankConnections)
+          ..where((c) => c.id.equals(id)))
+        .write(BankConnectionsCompanion(
+      status: Value(status),
+      errorMessage: Value(errorMessage),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  /// Update the last synced timestamp.
+  Future<void> updateLastSyncedAt(String id, int timestamp) {
+    return (_db.update(_db.bankConnections)
+          ..where((c) => c.id.equals(id)))
+        .write(BankConnectionsCompanion(
+      lastSyncedAt: Value(timestamp),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  /// Delete a connection by ID.
+  Future<int> deleteConnection(String id) {
+    return (_db.delete(_db.bankConnections)
+          ..where((c) => c.id.equals(id)))
+        .go();
+  }
+
+  /// Get count of connections.
+  Future<int> getConnectionCount() async {
+    final count = _db.bankConnections.id.count();
+    final result = await (_db.selectOnly(_db.bankConnections)
+          ..addColumns([count]))
+        .getSingle();
+    return result.read(count) ?? 0;
+  }
+}

--- a/lib/data/repositories/import_repository.dart
+++ b/lib/data/repositories/import_repository.dart
@@ -27,6 +27,18 @@ class ImportRepository {
         .get();
   }
 
+  /// Watch import history filtered by source, limited to most recent entries.
+  Stream<List<ImportHistoryData>> watchImportHistoryBySource(
+    String source, {
+    int limit = 10,
+  }) {
+    return (_db.select(_db.importHistory)
+          ..where((r) => r.source.equals(source))
+          ..orderBy([(r) => OrderingTerm.desc(r.createdAt)])
+          ..limit(limit))
+        .watch();
+  }
+
   /// Delete an import record by ID.
   Future<int> deleteImportRecord(String id) {
     return (_db.delete(_db.importHistory)..where((r) => r.id.equals(id))).go();

--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -169,6 +169,23 @@ class TransactionRepository {
     return (_db.delete(_db.transactions)..where((t) => t.id.equals(id))).go();
   }
 
+  /// Get a transaction by its external ID.
+  Future<Transaction?> getByExternalId(String externalId) {
+    return (_db.select(_db.transactions)
+          ..where((t) => t.externalId.equals(externalId))
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// Update the pending status of a transaction.
+  Future<void> updatePendingStatus(String id, bool isPending) {
+    return (_db.update(_db.transactions)..where((t) => t.id.equals(id)))
+        .write(TransactionsCompanion(
+      isPending: Value(isPending),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
   /// Check for duplicate by external ID.
   Future<bool> existsByExternalId(String externalId) async {
     final result = await (_db.select(_db.transactions)

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -1,0 +1,426 @@
+import 'package:drift/drift.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/error/app_error.dart';
+import '../../../data/local/database/app_database.dart';
+import '../../../data/local/secure_storage/secure_storage_service.dart';
+import '../../../data/remote/simplefin/simplefin_client.dart';
+import '../../../data/remote/simplefin/simplefin_models.dart';
+import '../../../data/repositories/account_repository.dart';
+import '../../../data/repositories/bank_connection_repository.dart';
+import '../../../data/repositories/import_repository.dart';
+import '../../../data/repositories/transaction_repository.dart';
+
+// =============================================================================
+// DATA CLASSES
+// =============================================================================
+
+/// Result of a sync operation.
+class SyncResult {
+  final String connectionId;
+  final int accountsUpdated;
+  final int transactionsImported;
+  final int transactionsSkipped;
+  final String? errorMessage;
+  final bool rateLimited;
+
+  const SyncResult({
+    required this.connectionId,
+    this.accountsUpdated = 0,
+    this.transactionsImported = 0,
+    this.transactionsSkipped = 0,
+    this.errorMessage,
+    this.rateLimited = false,
+  });
+}
+
+/// Connection status constants.
+class ConnectionStatus {
+  ConnectionStatus._();
+
+  static const String connected = 'connected';
+  static const String syncing = 'syncing';
+  static const String error = 'error';
+  static const String disconnected = 'disconnected';
+  static const String rateLimited = 'rate_limited';
+}
+
+// =============================================================================
+// SERVICE
+// =============================================================================
+
+/// Orchestrates SimpleFIN bank sync operations.
+///
+/// Handles token claiming, account syncing, rate limiting,
+/// and circuit breaker logic.
+class SimplefinSyncService {
+  SimplefinSyncService({
+    required SimplefinClient simplefinClient,
+    required SecureStorageService secureStorage,
+    required BankConnectionRepository connectionRepo,
+    required AccountRepository accountRepo,
+    required TransactionRepository transactionRepo,
+    required ImportRepository importRepo,
+  })  : _simplefinClient = simplefinClient,
+        _secureStorage = secureStorage,
+        _connectionRepo = connectionRepo,
+        _accountRepo = accountRepo,
+        _transactionRepo = transactionRepo,
+        _importRepo = importRepo;
+
+  final SimplefinClient _simplefinClient;
+  final SecureStorageService _secureStorage;
+  final BankConnectionRepository _connectionRepo;
+  final AccountRepository _accountRepo;
+  final TransactionRepository _transactionRepo;
+  final ImportRepository _importRepo;
+
+  /// Tracks consecutive sync failures for circuit breaker.
+  int _consecutiveFailures = 0;
+  DateTime? _lastFailureTime;
+
+  static const _uuid = Uuid();
+
+  /// Claim a setup token and create a bank connection.
+  ///
+  /// Returns the connection ID on success.
+  Future<String> claimAndConnect(String base64Token) async {
+    try {
+      // 1. Claim the token to get access URL
+      final accessUrl = await _simplefinClient.claimSetupToken(base64Token);
+
+      // 2. Store access URL in secure storage
+      await _secureStorage.setSimplefinToken(accessUrl.toString());
+
+      // 3. Fetch accounts (balances only) to get institution info
+      final response = await _simplefinClient.getAccounts(
+        accessUrl,
+        balancesOnly: true,
+      );
+
+      // Determine institution name from first account
+      String institutionName = 'SimpleFIN';
+      if (response.accounts.isNotEmpty) {
+        final first = response.accounts.first;
+        institutionName =
+            first.orgName ?? first.orgDomain ?? first.name;
+      }
+
+      // 4. Create bank connection record
+      final connectionId = _uuid.v4();
+      final now = DateTime.now().millisecondsSinceEpoch;
+
+      await _connectionRepo.insertConnection(BankConnectionsCompanion.insert(
+        id: connectionId,
+        provider: 'simplefin',
+        institutionName: institutionName,
+        status: ConnectionStatus.connected,
+        createdAt: now,
+        updatedAt: now,
+      ));
+
+      return connectionId;
+    } on SimplefinApiException catch (e) {
+      if (e.statusCode == 403) {
+        throw BankSyncError.tokenCompromised();
+      }
+      if (e.statusCode == 402) {
+        throw BankSyncError.paymentRequired();
+      }
+      throw BankSyncError(message: e.message);
+    }
+  }
+
+  /// Sync a connection's accounts and transactions.
+  ///
+  /// Returns a [SyncResult] with counts and status.
+  Future<SyncResult> syncConnection(String connectionId) async {
+    // Check rate limiting
+    if (!await canSync(connectionId)) {
+      return SyncResult(
+        connectionId: connectionId,
+        rateLimited: true,
+        errorMessage: 'Rate limited. Please wait before syncing again.',
+      );
+    }
+
+    try {
+      // Load access URL
+      final tokenString = await _secureStorage.getSimplefinToken();
+      if (tokenString == null) {
+        throw const BankSyncError(
+          message: 'No SimpleFIN credentials found. Please reconnect.',
+        );
+      }
+      final accessUrl = SimplefinAccessUrl.parse(tokenString);
+
+      // Set status to syncing
+      await _connectionRepo.updateStatus(
+        connectionId,
+        ConnectionStatus.syncing,
+      );
+
+      // Compute sync window
+      final connection = await _connectionRepo.getConnectionById(connectionId);
+      final now = DateTime.now();
+      int startDateUnix;
+
+      if (connection?.lastSyncedAt == null) {
+        // First sync: 90 days back
+        startDateUnix =
+            now.subtract(const Duration(days: 90)).millisecondsSinceEpoch ~/
+                1000;
+      } else {
+        // Subsequent: lastSyncedAt minus 3 days overlap
+        startDateUnix = (connection!.lastSyncedAt! -
+                const Duration(days: 3).inMilliseconds) ~/
+            1000;
+      }
+
+      // Fetch from SimpleFIN
+      final response = await _simplefinClient.getAccounts(
+        accessUrl,
+        startDate: startDateUnix,
+        includePending: true,
+      );
+
+      var accountsUpdated = 0;
+      var transactionsImported = 0;
+      var transactionsSkipped = 0;
+
+      // Process each account
+      for (final sfAccount in response.accounts) {
+        // Find linked local account
+        final linkedAccounts =
+            await _accountRepo.getAccountsByConnection(connectionId);
+        final localAccount = linkedAccounts
+            .where((a) => a.externalId == sfAccount.id)
+            .firstOrNull;
+
+        if (localAccount == null) continue;
+
+        // Update balance
+        await _accountRepo.updateBalance(
+          localAccount.id,
+          sfAccount.balanceCents,
+        );
+        await _accountRepo.updateLastSyncedAt(localAccount.id);
+        accountsUpdated++;
+
+        // Process transactions
+        for (final sfTxn in sfAccount.transactions) {
+          final externalId = '$connectionId:${sfTxn.id}';
+
+          // Check for existing transaction
+          final existing =
+              await _transactionRepo.getByExternalId(externalId);
+
+          if (existing != null) {
+            // When a pending transaction posts, update amount/date/description
+            // (banks often adjust these when a pending charge clears)
+            if (existing.isPending && !sfTxn.isPending) {
+              final dateUnixExisting =
+                  sfTxn.transactedAtUnix ?? sfTxn.postedUnix;
+              await _transactionRepo.updateTransaction(
+                TransactionsCompanion(
+                  id: Value(existing.id),
+                  amountCents: Value(sfTxn.amountCents),
+                  date: Value(dateUnixExisting * 1000),
+                  payee: Value(sfTxn.description),
+                  isPending: const Value(false),
+                  updatedAt: Value(now.millisecondsSinceEpoch),
+                ),
+              );
+            }
+            transactionsSkipped++;
+            continue;
+          }
+
+          // Determine date (prefer transactedAt, fall back to posted)
+          final dateUnix = sfTxn.transactedAtUnix ?? sfTxn.postedUnix;
+          final dateMillis = dateUnix * 1000;
+
+          // Insert new transaction
+          final txnId = _uuid.v4();
+          final nowMillis = now.millisecondsSinceEpoch;
+
+          await _transactionRepo.insertTransaction(
+            TransactionsCompanion.insert(
+              id: txnId,
+              accountId: localAccount.id,
+              amountCents: sfTxn.amountCents,
+              date: dateMillis,
+              payee: sfTxn.description,
+              externalId: Value(externalId),
+              isPending: Value(sfTxn.isPending),
+              createdAt: nowMillis,
+              updatedAt: nowMillis,
+            ),
+          );
+          transactionsImported++;
+        }
+      }
+
+      // Update connection
+      final nowMillis = now.millisecondsSinceEpoch;
+      await _connectionRepo.updateLastSyncedAt(connectionId, nowMillis);
+      await _connectionRepo.updateStatus(
+        connectionId,
+        ConnectionStatus.connected,
+      );
+
+      // Record import history
+      final institutionName =
+          connection?.institutionName ?? 'SimpleFIN';
+      await _importRepo.insertImportRecord(ImportHistoryCompanion.insert(
+        id: _uuid.v4(),
+        source: 'simplefin',
+        fileName: institutionName,
+        rowCount: transactionsImported + transactionsSkipped,
+        importedCount: transactionsImported,
+        skippedCount: transactionsSkipped,
+        status: 'completed',
+        createdAt: nowMillis,
+      ));
+
+      // Reset failure counter on success
+      _consecutiveFailures = 0;
+      _lastFailureTime = null;
+
+      return SyncResult(
+        connectionId: connectionId,
+        accountsUpdated: accountsUpdated,
+        transactionsImported: transactionsImported,
+        transactionsSkipped: transactionsSkipped,
+      );
+    } on SimplefinApiException catch (e) {
+      _recordFailure();
+      final errorMsg = e.message;
+      await _connectionRepo.updateStatus(
+        connectionId,
+        ConnectionStatus.error,
+        errorMessage: errorMsg,
+      );
+      return SyncResult(
+        connectionId: connectionId,
+        errorMessage: errorMsg,
+      );
+    } catch (e) {
+      _recordFailure();
+      final errorMsg = e is AppError ? e.message : e.toString();
+      await _connectionRepo.updateStatus(
+        connectionId,
+        ConnectionStatus.error,
+        errorMessage: errorMsg,
+      );
+      return SyncResult(
+        connectionId: connectionId,
+        errorMessage: errorMsg,
+      );
+    }
+  }
+
+  /// Check if a sync is allowed (rate limiting + circuit breaker).
+  Future<bool> canSync(String connectionId) async {
+    // Check circuit breaker
+    if (_consecutiveFailures >= AppConstants.maxConsecutiveSyncFailures) {
+      final backoff = _getBackoffDuration();
+      if (_lastFailureTime != null &&
+          DateTime.now().difference(_lastFailureTime!) < backoff) {
+        return false;
+      }
+      // Backoff period elapsed, allow retry
+    }
+
+    // Check minimum interval
+    final connection = await _connectionRepo.getConnectionById(connectionId);
+    if (connection?.lastSyncedAt != null) {
+      final lastSync =
+          DateTime.fromMillisecondsSinceEpoch(connection!.lastSyncedAt!);
+      final elapsed = DateTime.now().difference(lastSync);
+      if (elapsed.inMinutes < AppConstants.minSyncIntervalMinutes) {
+        return false;
+      }
+    }
+
+    // Check daily sync count (query ImportHistory for today's simplefin syncs)
+    final todayStart = DateTime.now();
+    final startOfDay =
+        DateTime(todayStart.year, todayStart.month, todayStart.day)
+            .millisecondsSinceEpoch;
+    final history = await _importRepo.getImportHistory();
+    final todaySyncs = history
+        .where((h) => h.source == 'simplefin' && h.createdAt >= startOfDay)
+        .length;
+    if (todaySyncs >= AppConstants.maxDailySyncs) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Get the time until the next sync is allowed.
+  Future<Duration?> timeUntilNextSync(String connectionId) async {
+    // Check circuit breaker first
+    if (_consecutiveFailures >= AppConstants.maxConsecutiveSyncFailures &&
+        _lastFailureTime != null) {
+      final backoff = _getBackoffDuration();
+      final elapsed = DateTime.now().difference(_lastFailureTime!);
+      if (elapsed < backoff) {
+        return backoff - elapsed;
+      }
+    }
+
+    // Check minimum interval
+    final connection = await _connectionRepo.getConnectionById(connectionId);
+    if (connection?.lastSyncedAt != null) {
+      final lastSync =
+          DateTime.fromMillisecondsSinceEpoch(connection!.lastSyncedAt!);
+      final elapsed = DateTime.now().difference(lastSync);
+      final minInterval =
+          Duration(minutes: AppConstants.minSyncIntervalMinutes);
+      if (elapsed < minInterval) {
+        return minInterval - elapsed;
+      }
+    }
+
+    return null;
+  }
+
+  /// Disconnect a bank connection.
+  ///
+  /// Clears credentials, unlinks accounts, updates status.
+  /// Does NOT delete transaction history.
+  Future<void> disconnect(String connectionId) async {
+    // Clear credentials
+    await _secureStorage.clearSimplefinToken();
+
+    // Unlink all accounts tied to this connection
+    final linkedAccounts =
+        await _accountRepo.getAccountsByConnection(connectionId);
+    for (final account in linkedAccounts) {
+      await _accountRepo.unlinkFromBank(account.id);
+    }
+
+    // Update connection status
+    await _connectionRepo.updateStatus(
+      connectionId,
+      ConnectionStatus.disconnected,
+    );
+  }
+
+  void _recordFailure() {
+    _consecutiveFailures++;
+    _lastFailureTime = DateTime.now();
+  }
+
+  /// Exponential backoff: 5min, 30min, 2hr.
+  Duration _getBackoffDuration() {
+    return switch (_consecutiveFailures) {
+      <= 3 => const Duration(minutes: 5),
+      <= 5 => const Duration(minutes: 30),
+      _ => const Duration(hours: 2),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Implements SimpleFIN Bridge protocol client (claim setup token, fetch accounts with Basic Auth)
- Adds bank connection repository, sync service with rate limiting (15-min interval, 24/day cap) and circuit breaker (exponential backoff after 3 failures)
- Extends AccountRepository, TransactionRepository, and ImportRepository with bank-linking and external ID support
- Adds Dio HTTP client with conservative timeouts (no retry interceptor due to rate limit constraints)
- Adds BankSyncError.paymentRequired/tokenCompromised error factories

## Files
**New (5):** dio_client, simplefin_client, simplefin_models, bank_connection_repository, simplefin_sync_service
**Modified (6):** app_constants, providers, app_error, account_repository, import_repository, transaction_repository

## Test plan
- [ ] `flutter analyze` passes
- [ ] Unit test SimplefinClient with mock Dio (claim + getAccounts)
- [ ] Unit test amount string-to-cents parsing edge cases
- [ ] Unit test BankConnectionRepository CRUD
- [ ] Unit test canSync rate limiting logic
- [ ] Unit test syncConnection with mock dependencies (dedup, balance updates, error handling)

> Part 1 of 3 — [PR 2: UI screens](#) and [PR 3: Background sync](#) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)