### PR TITLE
Add WorkManager background sync for SimpleFIN

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -21,6 +21,7 @@ import '../../domain/usecases/recurring/recurring_detection_service.dart';
 import '../../data/remote/dio_client.dart';
 import '../../data/remote/simplefin/simplefin_client.dart';
 import '../../data/repositories/bank_connection_repository.dart';
+import '../../domain/usecases/sync/background_sync_manager.dart';
 import '../../domain/usecases/sync/simplefin_sync_service.dart';
 import '../router/app_router.dart';
 
@@ -104,6 +105,10 @@ final simplefinSyncServiceProvider = Provider<SimplefinSyncService>((ref) {
     transactionRepo: ref.watch(transactionRepositoryProvider),
     importRepo: ref.watch(importRepositoryProvider),
   );
+});
+
+final backgroundSyncManagerProvider = Provider<BackgroundSyncManager>((ref) {
+  return BackgroundSyncManager();
 });
 
 // =============================================================================

--- a/lib/domain/usecases/sync/background_sync_callback.dart
+++ b/lib/domain/usecases/sync/background_sync_callback.dart
@@ -1,0 +1,59 @@
+import 'package:workmanager/workmanager.dart';
+
+import '../../../data/local/database/app_database.dart';
+import '../../../data/local/secure_storage/secure_storage_service.dart';
+import '../../../data/remote/dio_client.dart';
+import '../../../data/remote/simplefin/simplefin_client.dart';
+import '../../../data/repositories/account_repository.dart';
+import '../../../data/repositories/bank_connection_repository.dart';
+import '../../../data/repositories/import_repository.dart';
+import '../../../data/repositories/transaction_repository.dart';
+import '../../../domain/usecases/sync/simplefin_sync_service.dart';
+
+import 'background_sync_manager.dart';
+
+/// Top-level callback dispatcher for WorkManager.
+///
+/// Runs in a separate isolate on Android — cannot use Riverpod providers.
+/// Opens its own database instance and creates dependencies manually.
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    if (taskName != backgroundSyncTaskName) return true;
+
+    AppDatabase? db;
+    try {
+      db = await AppDatabase.open();
+
+      final secureStorage = SecureStorageService();
+      final dio = createDioClient();
+      final simplefinClient = SimplefinClient(dio);
+      final connectionRepo = BankConnectionRepository(db);
+      final accountRepo = AccountRepository(db);
+      final transactionRepo = TransactionRepository(db);
+      final importRepo = ImportRepository(db);
+
+      final syncService = SimplefinSyncService(
+        simplefinClient: simplefinClient,
+        secureStorage: secureStorage,
+        connectionRepo: connectionRepo,
+        accountRepo: accountRepo,
+        transactionRepo: transactionRepo,
+        importRepo: importRepo,
+      );
+
+      // Sync all active connections
+      final connections = await connectionRepo.getAllConnections();
+      for (final connection in connections) {
+        if (connection.status == ConnectionStatus.disconnected) continue;
+        await syncService.syncConnection(connection.id);
+      }
+
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      await db?.close();
+    }
+  });
+}

--- a/lib/domain/usecases/sync/background_sync_manager.dart
+++ b/lib/domain/usecases/sync/background_sync_manager.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:workmanager/workmanager.dart';
+
+import '../../../core/constants/app_constants.dart';
+
+/// Task name for WorkManager registration.
+const backgroundSyncTaskName = 'simplefin_sync';
+
+/// Manages registration and cancellation of background sync tasks.
+///
+/// Uses WorkManager on Android and Timer.periodic on Linux desktop.
+class BackgroundSyncManager {
+  BackgroundSyncManager();
+
+  Timer? _linuxTimer;
+  bool _registered = false;
+
+  /// Register periodic background sync.
+  Future<void> register({
+    required Future<void> Function() syncCallback,
+  }) async {
+    if (_registered) return;
+
+    final interval = Duration(
+      hours: AppConstants.backgroundSyncIntervalHours,
+    );
+
+    if (Platform.isAndroid) {
+      await Workmanager().registerPeriodicTask(
+        backgroundSyncTaskName,
+        backgroundSyncTaskName,
+        frequency: interval,
+        constraints: Constraints(
+          networkType: NetworkType.connected,
+        ),
+        existingWorkPolicy: ExistingWorkPolicy.keep,
+      );
+    } else if (Platform.isLinux) {
+      // Linux: in-process timer (runs only while app is open)
+      _linuxTimer = Timer.periodic(interval, (_) async {
+        try {
+          await syncCallback();
+        } catch (e) {
+          if (kDebugMode) {
+            print('Background sync error: $e');
+          }
+        }
+      });
+    }
+
+    _registered = true;
+  }
+
+  /// Cancel all background sync tasks.
+  Future<void> cancel() async {
+    if (Platform.isAndroid) {
+      await Workmanager().cancelByUniqueName(backgroundSyncTaskName);
+    }
+    _linuxTimer?.cancel();
+    _linuxTimer = null;
+    _registered = false;
+  }
+
+  /// Whether background sync is currently registered.
+  bool get isRegistered => _registered;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,23 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:workmanager/workmanager.dart';
 
 import 'app.dart';
 import 'core/di/providers.dart';
 import 'data/local/database/app_database.dart';
 import 'data/repositories/category_repository.dart';
 import 'domain/usecases/categories/category_seeder.dart';
+import 'domain/usecases/sync/background_sync_callback.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Initialize WorkManager for background sync (Android only)
+  if (Platform.isAndroid) {
+    await Workmanager().initialize(callbackDispatcher);
+  }
 
   // Open the database
   final database = await AppDatabase.open();


### PR DESCRIPTION
## Summary
- BackgroundSyncManager with register/cancel/isRegistered API
- WorkManager periodic task (8-hour interval) on Android with network connectivity constraint
- Timer.periodic fallback on Linux (in-process only)
- Isolate-safe callbackDispatcher creates own DB + service instances
- WorkManager initialized in main.dart before database setup
- backgroundSyncManagerProvider added to DI

## Files
**New (2):** background_sync_manager, background_sync_callback
**Modified (2):** providers (add backgroundSyncManagerProvider), main.dart (WorkManager init)

## Test plan
- [ ] `flutter analyze` passes
- [ ] Unit test register/cancel lifecycle
- [ ] Verify WorkManager constraints (network required)
- [ ] Manual: verify 8-hour sync doesn't exceed 24/day limit (3 auto + 21 manual)
- [ ] Full `flutter test` suite passes

> Part 3 of 3 — builds on [PR 2: UI](https://github.com/bloknayrb/patrimonium/pull/17) and [PR 1: Data layer](https://github.com/bloknayrb/patrimonium/pull/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)