### PR TITLE
Add SimpleFIN bank connection UI screens

### DIFF
--- a/lib/domain/usecases/sync/background_sync_manager.dart
+++ b/lib/domain/usecases/sync/background_sync_manager.dart
@@ -24,7 +24,7 @@ class BackgroundSyncManager {
   }) async {
     if (_registered) return;
 
-    final interval = Duration(
+    const interval = Duration(
       hours: AppConstants.backgroundSyncIntervalHours,
     );
 

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -380,7 +380,7 @@ class SimplefinSyncService {
           DateTime.fromMillisecondsSinceEpoch(connection!.lastSyncedAt!);
       final elapsed = DateTime.now().difference(lastSync);
       final minInterval =
-          Duration(minutes: AppConstants.minSyncIntervalMinutes);
+          const Duration(minutes: AppConstants.minSyncIntervalMinutes);
       if (elapsed < minInterval) {
         return minInterval - elapsed;
       }

--- a/lib/presentation/features/bank_connections/connection_detail_screen.dart
+++ b/lib/presentation/features/bank_connections/connection_detail_screen.dart
@@ -40,7 +40,7 @@ class ConnectionDetailScreen extends ConsumerWidget {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              _SectionTitle(title: 'Connection Info'),
+              const _SectionTitle(title: 'Connection Info'),
               _InfoRow('Institution', connection.institutionName),
               _InfoRow('Provider', connection.provider),
               _InfoRow('Status', connection.status),
@@ -74,7 +74,7 @@ class ConnectionDetailScreen extends ConsumerWidget {
                 ),
               ],
               const SizedBox(height: 20),
-              _SectionTitle(title: 'Linked Accounts'),
+              const _SectionTitle(title: 'Linked Accounts'),
               linkedAsync.when(
                 loading: () => const Padding(
                     padding: EdgeInsets.all(16),
@@ -102,7 +102,7 @@ class ConnectionDetailScreen extends ConsumerWidget {
                 },
               ),
               const SizedBox(height: 20),
-              _SectionTitle(title: 'Sync History'),
+              const _SectionTitle(title: 'Sync History'),
               historyAsync.when(
                 loading: () => const Padding(
                     padding: EdgeInsets.all(16),
@@ -120,7 +120,7 @@ class ConnectionDetailScreen extends ConsumerWidget {
                 },
               ),
               const SizedBox(height: 20),
-              _SectionTitle(title: 'Actions'),
+              const _SectionTitle(title: 'Actions'),
               const SizedBox(height: 8),
               Row(
                 children: [

--- a/lib/presentation/features/settings/settings_screen.dart
+++ b/lib/presentation/features/settings/settings_screen.dart
@@ -198,9 +198,9 @@ class SettingsScreen extends ConsumerWidget {
 
           // About
           const _SectionHeader(title: 'About'),
-          ListTile(
-            leading: const Icon(Icons.info_outline),
-            title: const Text(AppConstants.appName),
+          const ListTile(
+            leading: Icon(Icons.info_outline),
+            title: Text(AppConstants.appName),
             subtitle: Text('Version ${AppConstants.appVersion}'),
           ),
           ListTile(


### PR DESCRIPTION
## Summary

- **4 new screens**: Bank connections list, SimpleFIN setup wizard (claim URL flow), account linking with type mapping, and connection detail with sync history
- **7 Riverpod providers**: State management for connections list, setup flow, account linking, sync status, linked accounts, sync history, and manual sync triggers
- **3 reusable widgets**: `ConnectionCard` (status badges, sync indicators), `AccountLinkCard` (account type picker with balance preview), `SyncHistoryCard` (timestamped sync results)
- **4 new routes** wired into GoRouter: `/connections`, `/connections/setup`, `/connections/:id/link`, `/connections/:id`
- **Settings integration**: "Bank Connections" entry point added to settings screen
- **Background sync**: WorkManager registration in `main.dart` with top-level callback handler
- **Database**: Added `SyncHistory` table for tracking sync operations with status, counts, and error messages

Builds on the already-merged data layer (PR #16) and background sync (PR #18). This is the final piece that gives users the ability to set up SimpleFIN connections, link external accounts, and manage syncs.

## Test plan

- [ ] `flutter analyze` passes clean (0 issues)
- [ ] `flutter test` passes (31/31)
- [ ] Navigate to Settings > Bank Connections
- [ ] Complete SimpleFIN setup wizard with a claim URL
- [ ] Link external accounts with correct type mapping
- [ ] View connection detail with sync history
- [ ] Trigger manual sync from connection detail
- [ ] Disconnect a connection and verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)