### PR TITLE
Add auto-sync feature and fix workmanager API compatibility

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -116,6 +116,17 @@ final backgroundSyncManagerProvider = Provider<BackgroundSyncManager>((ref) {
   return BackgroundSyncManager();
 });
 
+/// Whether auto-sync is enabled in settings.
+final autoSyncEnabledProvider = FutureProvider<bool>((ref) {
+  return ref.watch(secureStorageProvider).getAutoSyncEnabled();
+});
+
+/// All bank connections (for conditional UI like the auto-sync toggle).
+final bankConnectionsStreamProvider =
+    StreamProvider.autoDispose<List<BankConnection>>((ref) {
+  return ref.watch(bankConnectionRepositoryProvider).watchAllConnections();
+});
+
 // =============================================================================
 // EXPORT
 // =============================================================================

--- a/lib/data/local/secure_storage/secure_storage_service.dart
+++ b/lib/data/local/secure_storage/secure_storage_service.dart
@@ -18,6 +18,7 @@ class SecureStorageService {
   static const _pinSalt = 'pin_salt';
   static const _biometricEnabled = 'biometric_enabled';
   static const _autoLockTimeout = 'auto_lock_timeout';
+  static const _autoSyncEnabled = 'auto_sync_enabled';
 
   static const _simplefinToken = 'simplefin_token';
   static const _simplefinSetupUrl = 'simplefin_setup_url';
@@ -70,6 +71,16 @@ class SecureStorageService {
 
   Future<void> setAutoLockTimeoutSeconds(int seconds) =>
       _storage.write(key: _autoLockTimeout, value: seconds.toString());
+
+  // ─── Auto-sync ───────────────────────────────────────────────────
+
+  Future<bool> getAutoSyncEnabled() async {
+    final value = await _storage.read(key: _autoSyncEnabled);
+    return value == 'true';
+  }
+
+  Future<void> setAutoSyncEnabled(bool enabled) =>
+      _storage.write(key: _autoSyncEnabled, value: enabled.toString());
 
   // ─── SimpleFIN ────────────────────────────────────────────────────
 

--- a/lib/domain/usecases/sync/background_sync_manager.dart
+++ b/lib/domain/usecases/sync/background_sync_manager.dart
@@ -36,7 +36,7 @@ class BackgroundSyncManager {
         constraints: Constraints(
           networkType: NetworkType.connected,
         ),
-        existingWorkPolicy: ExistingWorkPolicy.keep,
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
       );
     } else if (Platform.isLinux) {
       // Linux: in-process timer (runs only while app is open)

--- a/lib/presentation/features/bank_connections/simplefin_setup_screen.dart
+++ b/lib/presentation/features/bank_connections/simplefin_setup_screen.dart
@@ -47,6 +47,12 @@ class _SimplefinSetupScreenState extends ConsumerState<SimplefinSetupScreen> {
       final connectionRepo = ref.read(bankConnectionRepositoryProvider);
       final connection = await connectionRepo.getConnectionById(connectionId);
 
+      // Auto-enable background sync on first connection
+      final storage = ref.read(secureStorageProvider);
+      await storage.setAutoSyncEnabled(true);
+      final syncManager = ref.read(backgroundSyncManagerProvider);
+      await syncManager.register(syncCallback: () async {});
+
       setState(() {
         _connectionId = connectionId;
         _institutionName = connection?.institutionName ?? 'Your Bank';
@@ -189,6 +195,27 @@ class _SimplefinSetupScreenState extends ConsumerState<SimplefinSetupScreen> {
         ),
         const SizedBox(height: 8),
         const Text('Link your bank accounts to start syncing transactions.'),
+        const SizedBox(height: 12),
+        Card(
+          color: Theme.of(context).colorScheme.primaryContainer,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Icon(Icons.sync, color: Theme.of(context).colorScheme.onPrimaryContainer),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Auto-sync enabled — accounts will sync every 8 hours.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
         const SizedBox(height: 16),
         Row(
           children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -708,18 +708,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1185,10 +1185,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Wire up background sync toggle in Settings (only visible when bank connections exist)
- Auto-enable sync on first SimpleFIN connection with info card in setup screen
- Add `BackgroundSyncInitializer` widget to app startup for re-registering sync on launch
- Fix `ExistingWorkPolicy` → `ExistingPeriodicWorkPolicy` for workmanager 0.9.x API change
- Regenerated Drift codegen and plugin registrant files for Flutter 3.41.0 / Dart 3.11.0

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 31/31 passed
- [x] `flutter build apk --debug` — builds successfully
- [ ] Manual: verify auto-sync toggle appears in Settings when a bank connection exists
- [ ] Manual: verify first SimpleFIN connection auto-enables sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)