### PR TITLE
Fix biometric authentication not working on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
     <application
         android:label="patrimonium"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/patrimonium/patrimonium/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/patrimonium/patrimonium/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.patrimonium.patrimonium
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterFragmentActivity()

--- a/lib/presentation/features/settings/settings_screen.dart
+++ b/lib/presentation/features/settings/settings_screen.dart
@@ -140,7 +140,20 @@ class SettingsScreen extends ConsumerWidget {
                 value: biometricEnabled.valueOrNull ?? false,
                 onChanged: (value) async {
                   final biometricService = ref.read(biometricServiceProvider);
-                  await biometricService.setEnabled(value);
+                  if (value) {
+                    // Verify biometric works before enabling
+                    final success = await biometricService.verifyAndEnable();
+                    if (!success && context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content:
+                              Text('Biometric authentication failed. Please try again.'),
+                        ),
+                      );
+                    }
+                  } else {
+                    await biometricService.setEnabled(false);
+                  }
                   ref.invalidate(biometricEnabledProvider);
                 },
               ),


### PR DESCRIPTION
Three issues prevented biometric auth from functioning:

1. MainActivity extended FlutterActivity instead of FlutterFragmentActivity,
   which local_auth requires to display the biometric prompt dialog.
2. Missing USE_BIOMETRIC permission in AndroidManifest.xml.
3. Settings toggle blindly persisted the preference without verifying
   biometric actually works — now prompts the user to authenticate
   before enabling, with error feedback on failure.

https://claude.ai/code/session_017jW64XCP9jQULmcJER6qoF