### PR TITLE
LLM (7/8): Add conversation list and streaming chat UI

### DIFF
--- a/lib/presentation/features/ai_assistant/ai_assistant_providers.dart
+++ b/lib/presentation/features/ai_assistant/ai_assistant_providers.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../data/local/database/app_database.dart';
+
+/// All conversations, most recent first.
+final conversationsProvider =
+    StreamProvider.autoDispose<List<Conversation>>((ref) {
+  return ref.watch(conversationRepositoryProvider).watchAllConversations();
+});
+
+/// Messages for a specific conversation, ordered oldest first.
+final messagesProvider =
+    StreamProvider.autoDispose.family<List<Message>, String>((ref, id) {
+  return ref.watch(conversationRepositoryProvider).watchMessages(id);
+});
+
+/// Whether the LLM is currently generating a response.
+final isStreamingProvider = StateProvider.autoDispose<bool>((ref) => false);
+
+/// Accumulated streaming text chunks for live display before DB save.
+final streamingTextProvider =
+    StateProvider.autoDispose<String>((ref) => '');

--- a/lib/presentation/features/ai_assistant/ai_assistant_screen.dart
+++ b/lib/presentation/features/ai_assistant/ai_assistant_screen.dart
@@ -1,25 +1,186 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../core/di/providers.dart';
+import '../../../core/router/app_router.dart';
+import '../../../data/local/database/app_database.dart';
 import '../../shared/empty_states/empty_state_widget.dart';
+import '../../shared/loading/shimmer_loading.dart';
+import '../../shared/widgets/delete_confirmation_dialog.dart' show showDeleteConfirmation;
+import 'ai_assistant_providers.dart';
 
-/// AI Assistant chat screen — placeholder until LLM backend is wired.
+/// Conversation list screen — root of the AI assistant tab.
 class AiAssistantScreen extends ConsumerWidget {
   const AiAssistantScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final clientAsync = ref.watch(activeLlmClientProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('AI Assistant'),
+        actions: [
+          if (clientAsync.valueOrNull != null)
+            IconButton(
+              icon: const Icon(Icons.add),
+              tooltip: 'New conversation',
+              onPressed: () => _newConversation(context, ref),
+            ),
+        ],
       ),
-      body: const EmptyStateWidget(
-        icon: Icons.smart_toy,
-        title: 'Coming Soon',
-        description:
-            'Your personal financial assistant is on the way. '
-            'Configure an LLM provider in Settings once this feature is ready.',
+      body: clientAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => EmptyStateWidget(
+          icon: Icons.smart_toy,
+          title: 'Set Up AI Assistant',
+          description: 'Configure an LLM provider to get started.',
+          actionLabel: 'Configure',
+          actionIcon: Icons.settings,
+          onAction: () => context.push(AppRoutes.llmSettings),
+        ),
+        data: (client) {
+          if (client == null) {
+            return EmptyStateWidget(
+              icon: Icons.smart_toy,
+              title: 'Set Up AI Assistant',
+              description:
+                  'Connect to Gemini, Claude, OpenAI, or a local Ollama '
+                  'server to analyze your finances.',
+              actionLabel: 'Configure',
+              actionIcon: Icons.settings,
+              onAction: () => context.push(AppRoutes.llmSettings),
+            );
+          }
+          return _ConversationList(onNewConversation: () => _newConversation(context, ref));
+        },
       ),
     );
+  }
+
+  Future<void> _newConversation(BuildContext context, WidgetRef ref) async {
+    final clientAsync = ref.read(activeLlmClientProvider);
+    final client = clientAsync.valueOrNull;
+    if (client == null) return;
+
+    final repo = ref.read(conversationRepositoryProvider);
+    final conversationId =
+        await repo.createConversation(client.providerName, client.modelName);
+
+    if (context.mounted) {
+      context.push('${AppRoutes.aiChat}/$conversationId');
+    }
+  }
+}
+
+class _ConversationList extends ConsumerWidget {
+  final VoidCallback onNewConversation;
+
+  const _ConversationList({required this.onNewConversation});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conversations = ref.watch(conversationsProvider);
+
+    return conversations.when(
+      loading: () => const ShimmerTransactionList(itemCount: 4),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (items) {
+        if (items.isEmpty) {
+          return EmptyStateWidget(
+            icon: Icons.chat_bubble_outline,
+            title: 'No Conversations Yet',
+            description: 'Start a conversation to get AI insights on your finances.',
+            actionLabel: 'Start Conversation',
+            onAction: onNewConversation,
+          );
+        }
+
+        return ListView.builder(
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final conversation = items[index];
+            return _ConversationTile(
+              conversation: conversation,
+              onDelete: () => _deleteConversation(context, ref, conversation),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _deleteConversation(
+      BuildContext context, WidgetRef ref, Conversation c) async {
+    final confirmed = await showDeleteConfirmation(
+      context,
+      itemName: 'Conversation',
+      message: 'This conversation and all its messages will be deleted.',
+    );
+    if (confirmed) {
+      await ref.read(conversationRepositoryProvider).deleteConversation(c.id);
+    }
+  }
+}
+
+class _ConversationTile extends StatelessWidget {
+  final Conversation conversation;
+  final VoidCallback onDelete;
+
+  const _ConversationTile({
+    required this.conversation,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final title = conversation.title ?? 'New Conversation';
+    final date = DateTime.fromMillisecondsSinceEpoch(conversation.updatedAt);
+    final dateLabel = _formatDate(date);
+
+    return Dismissible(
+      key: ValueKey(conversation.id),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 16),
+        color: Theme.of(context).colorScheme.error,
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      confirmDismiss: (_) async {
+        onDelete();
+        return false; // Let the repo update handle list refresh
+      },
+      child: ListTile(
+        leading: const Icon(Icons.chat_bubble_outline),
+        title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        subtitle: Text(
+          conversation.model,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        trailing: Text(
+          dateLabel,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+        onTap: () {
+          context.push('${AppRoutes.aiChat}/${conversation.id}');
+        },
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    if (date.day == now.day &&
+        date.month == now.month &&
+        date.year == now.year) {
+      final h = date.hour.toString().padLeft(2, '0');
+      final m = date.minute.toString().padLeft(2, '0');
+      return '$h:$m';
+    }
+    return '${date.month}/${date.day}';
   }
 }

--- a/lib/presentation/features/ai_assistant/ai_chat_screen.dart
+++ b/lib/presentation/features/ai_assistant/ai_chat_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../domain/usecases/ai/chat_service.dart';
+import 'ai_assistant_providers.dart';
+import 'widgets/chat_input_bar.dart';
+import 'widgets/chat_message_bubble.dart';
+
+/// Full-screen chat view for a single conversation.
+class AiChatScreen extends ConsumerStatefulWidget {
+  final String conversationId;
+
+  const AiChatScreen({super.key, required this.conversationId});
+
+  @override
+  ConsumerState<AiChatScreen> createState() => _AiChatScreenState();
+}
+
+class _AiChatScreenState extends ConsumerState<AiChatScreen> {
+  final _scrollController = ScrollController();
+  bool _showDisclaimer = true;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  Future<void> _sendMessage(String text) async {
+    final clientAsync = ref.read(activeLlmClientProvider);
+    final client = clientAsync.valueOrNull;
+    if (client == null) return;
+
+    setState(() => _showDisclaimer = false);
+
+    ref.read(isStreamingProvider.notifier).state = true;
+    ref.read(streamingTextProvider.notifier).state = '';
+
+    String accumulated = '';
+
+    try {
+      final chatService = ref.read(chatServiceProvider);
+      await for (final chunk in chatService.sendMessage(
+        client: client,
+        conversationId: widget.conversationId,
+        userMessage: text,
+      )) {
+        accumulated += chunk;
+        ref.read(streamingTextProvider.notifier).state = accumulated;
+        _scrollToBottom();
+      }
+    } on RateLimitException {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('Daily limit reached. Try again tomorrow.')),
+        );
+      }
+    } catch (e) {
+      final msg = e.toString();
+      if (mounted) {
+        String snackText = 'Something went wrong.';
+        if (msg.contains('401') || msg.contains('403')) {
+          snackText = 'Invalid API key. Fix in Settings.';
+        } else if (msg.contains('429')) {
+          snackText = 'Rate limited. Try again later.';
+        } else if (msg.contains('connection') || msg.contains('timeout')) {
+          snackText = 'No connection.';
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(snackText)),
+        );
+      }
+    } finally {
+      if (mounted) {
+        ref.read(isStreamingProvider.notifier).state = false;
+        ref.read(streamingTextProvider.notifier).state = '';
+        _scrollToBottom();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = ref.watch(messagesProvider(widget.conversationId));
+    final isStreaming = ref.watch(isStreamingProvider);
+    final streamingText = ref.watch(streamingTextProvider);
+
+    // Auto-scroll when new messages arrive
+    ref.listen(messagesProvider(widget.conversationId), (prev, next) {
+      _scrollToBottom();
+    });
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI Assistant'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: messages.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+              data: (msgs) {
+                final itemCount = msgs.length +
+                    (_showDisclaimer && msgs.isEmpty ? 1 : 0) +
+                    (isStreaming && streamingText.isNotEmpty ? 1 : 0);
+
+                if (itemCount == 0) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(32),
+                      child: Text(
+                        'Ask anything about your finances.',
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  );
+                }
+
+                return ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(16),
+                  itemCount: itemCount,
+                  itemBuilder: (context, index) {
+                    // Disclaimer as first item when conversation is new
+                    if (_showDisclaimer && msgs.isEmpty && index == 0) {
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: Text(
+                          'AI responses are for informational purposes only, '
+                          'not professional financial advice.',
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurfaceVariant,
+                                fontStyle: FontStyle.italic,
+                              ),
+                          textAlign: TextAlign.center,
+                        ),
+                      );
+                    }
+
+                    // Adjust index for disclaimer offset
+                    final msgIndex =
+                        (_showDisclaimer && msgs.isEmpty) ? index - 1 : index;
+
+                    // Streaming bubble at the end
+                    if (isStreaming &&
+                        streamingText.isNotEmpty &&
+                        msgIndex == msgs.length) {
+                      return ChatMessageBubble(
+                        role: 'assistant',
+                        content: streamingText,
+                        isStreaming: true,
+                      );
+                    }
+
+                    if (msgIndex < 0 || msgIndex >= msgs.length) {
+                      return const SizedBox.shrink();
+                    }
+
+                    final msg = msgs[msgIndex];
+                    return ChatMessageBubble(
+                      key: ValueKey(msg.id),
+                      role: msg.role,
+                      content: msg.content,
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          const Divider(height: 1),
+          ChatInputBar(
+            isStreaming: isStreaming,
+            onSend: _sendMessage,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/ai_assistant/widgets/chat_input_bar.dart
+++ b/lib/presentation/features/ai_assistant/widgets/chat_input_bar.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+/// Chat input bar with multi-line text field and send button.
+class ChatInputBar extends StatefulWidget {
+  final bool isStreaming;
+  final void Function(String message) onSend;
+
+  const ChatInputBar({
+    super.key,
+    required this.isStreaming,
+    required this.onSend,
+  });
+
+  @override
+  State<ChatInputBar> createState() => _ChatInputBarState();
+}
+
+class _ChatInputBarState extends State<ChatInputBar> {
+  final _controller = TextEditingController();
+  bool _hasText = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      final hasText = _controller.text.trim().isNotEmpty;
+      if (hasText != _hasText) setState(() => _hasText = hasText);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final text = _controller.text.trim();
+    if (text.isEmpty || widget.isStreaming) return;
+    _controller.clear();
+    widget.onSend(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.newline,
+                enabled: !widget.isStreaming,
+                decoration: const InputDecoration(
+                  hintText: 'Ask about your finances…',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(24)),
+                  ),
+                  contentPadding:
+                      EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton.filled(
+              onPressed:
+                  _hasText && !widget.isStreaming ? _submit : null,
+              icon: const Icon(Icons.send),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/ai_assistant/widgets/chat_message_bubble.dart
+++ b/lib/presentation/features/ai_assistant/widgets/chat_message_bubble.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// A single chat message bubble.
+///
+/// User messages are right-aligned with primary background.
+/// Assistant messages are left-aligned with surface background and markdown rendering.
+class ChatMessageBubble extends StatelessWidget {
+  final String role; // 'user' or 'assistant'
+  final String content;
+  final bool isStreaming;
+
+  const ChatMessageBubble({
+    super.key,
+    required this.role,
+    required this.content,
+    this.isStreaming = false,
+  });
+
+  bool get _isUser => role == 'user';
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isUser = _isUser;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: EdgeInsets.only(
+          left: isUser ? 48 : 0,
+          right: isUser ? 0 : 48,
+          top: 4,
+          bottom: 4,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: isUser
+              ? colorScheme.primary
+              : colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(16),
+            topRight: const Radius.circular(16),
+            bottomLeft: Radius.circular(isUser ? 16 : 4),
+            bottomRight: Radius.circular(isUser ? 4 : 16),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isUser)
+              Text(
+                content,
+                style: TextStyle(color: colorScheme.onPrimary),
+              )
+            else
+              MarkdownBody(
+                data: content,
+                styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
+                    .copyWith(
+                  p: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurface,
+                      ),
+                ),
+                onTapLink: (text, href, title) {
+                  // Only allow https:// links — prevent tel:, sms:, etc.
+                  if (href != null && href.startsWith('https://')) {
+                    launchUrl(Uri.parse(href),
+                        mode: LaunchMode.externalApplication);
+                  }
+                },
+              ),
+            if (isStreaming) ...[
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                backgroundColor:
+                    colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                color: colorScheme.primary,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/shared/empty_states/empty_state_widget.dart
+++ b/lib/presentation/shared/empty_states/empty_state_widget.dart
@@ -7,6 +7,7 @@ class EmptyStateWidget extends StatelessWidget {
   final String description;
   final String? actionLabel;
   final VoidCallback? onAction;
+  final IconData actionIcon;
 
   const EmptyStateWidget({
     super.key,
@@ -15,6 +16,7 @@ class EmptyStateWidget extends StatelessWidget {
     required this.description,
     this.actionLabel,
     this.onAction,
+    this.actionIcon = Icons.add,
   });
 
   @override
@@ -59,7 +61,7 @@ class EmptyStateWidget extends StatelessWidget {
               const SizedBox(height: 24),
               FilledButton.icon(
                 onPressed: onAction,
-                icon: const Icon(Icons.add),
+                icon: Icon(actionIcon),
                 label: Text(actionLabel!),
               ),
             ],


### PR DESCRIPTION
## Summary
- `AiAssistantScreen` rewritten as conversation list: shimmer loading, swipe-to-delete with confirmation, empty state with configure/start CTAs
- `AiChatScreen`: streaming bubbles with live `streamingTextProvider`, auto-scroll on each chunk, disclaimer on new conversations, per-error-type snackbars (invalid key, rate limit, no connection)
- `ChatMessageBubble`: user messages right-aligned (primary bg), assistant messages left-aligned with `flutter_markdown` + `https://`-only link filter
- `ChatInputBar`: multiline input (1-4 lines), disabled during streaming
- `EmptyStateWidget`: add `actionIcon` param (default `Icons.add`)
- Route: `/ai/chat/:conversationId`

## Test plan
- [ ] AI tab shows empty state when no provider configured → Configure button goes to settings
- [ ] Start conversation → ask question → see streaming response
- [ ] Close and reopen → conversation list shows previous chat
- [ ] Swipe to delete → confirmation dialog → removed from list
- [ ] `flutter analyze` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)