### PR TITLE
LLM (8/8): Wire AI insights card on dashboard

### DIFF
--- a/lib/presentation/features/dashboard/widgets/ai_insights_card.dart
+++ b/lib/presentation/features/dashboard/widgets/ai_insights_card.dart
@@ -1,11 +1,63 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AiInsightsCard extends StatelessWidget {
+import '../../../../core/di/providers.dart';
+import '../../../../data/remote/llm/llm_client.dart';
+import '../../../../domain/usecases/ai/chat_service.dart';
+
+class AiInsightsCard extends ConsumerStatefulWidget {
   const AiInsightsCard({super.key});
+
+  @override
+  ConsumerState<AiInsightsCard> createState() => _AiInsightsCardState();
+}
+
+class _AiInsightsCardState extends ConsumerState<AiInsightsCard> {
+  String? _insight;
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _analyzeSpending() async {
+    final clientAsync = ref.read(activeLlmClientProvider);
+    final client = clientAsync.valueOrNull;
+    if (client == null) return;
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final contextBuilder = ref.read(contextBuilderProvider);
+      final context = await contextBuilder.buildContext();
+
+      final result = await client.complete(
+        'You are a personal finance assistant. Be concise — 2-3 sentences max.',
+        [
+          ChatMessage(role: 'context', content: context),
+          const ChatMessage(
+            role: 'user',
+            content:
+                'Give me one key insight about my spending this month. Be specific with numbers.',
+          ),
+        ],
+      );
+
+      if (mounted) setState(() => _insight = result);
+    } on RateLimitException {
+      if (mounted) setState(() => _error = 'Daily limit reached.');
+    } catch (e) {
+      if (mounted) setState(() => _error = 'Analysis failed.');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final clientAsync = ref.watch(activeLlmClientProvider);
+    final hasClient = clientAsync.valueOrNull != null;
 
     return Card(
       child: Padding(
@@ -15,7 +67,8 @@ class AiInsightsCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                Icon(Icons.auto_awesome, size: 20, color: theme.colorScheme.primary),
+                Icon(Icons.auto_awesome,
+                    size: 20, color: theme.colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   'AI Insights',
@@ -26,17 +79,30 @@ class AiInsightsCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12),
-            Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
+            if (!hasClient)
+              Center(
                 child: Text(
                   'Add financial data to get personalized insights',
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
+              )
+            else if (_loading)
+              const Center(child: CircularProgressIndicator())
+            else if (_error != null)
+              Text(_error!,
+                  style: TextStyle(color: theme.colorScheme.error))
+            else if (_insight != null)
+              Text(_insight!, style: theme.textTheme.bodyMedium)
+            else
+              Center(
+                child: FilledButton.icon(
+                  onPressed: _analyzeSpending,
+                  icon: const Icon(Icons.auto_awesome, size: 18),
+                  label: const Text('Analyze Spending'),
+                ),
               ),
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- `AiInsightsCard` upgraded from placeholder to `ConsumerStatefulWidget`
- When LLM is configured: shows "Analyze Spending" button that triggers a one-shot `complete()` with fresh financial context
- Displays result inline, or error message on failure (rate limit, generic)
- When LLM not configured: keeps original placeholder text

## Test plan
- [ ] Dashboard with LLM configured → Analyze Spending → insight appears
- [ ] Dashboard without LLM configured → placeholder text shown
- [ ] `flutter analyze` passes clean
- [ ] `flutter build apk --debug` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)