### PR TITLE
Fix stale transaction filters after tab navigation

### DIFF
--- a/lib/presentation/features/transactions/transactions_screen.dart
+++ b/lib/presentation/features/transactions/transactions_screen.dart
@@ -23,6 +23,22 @@ class _TransactionsScreenState extends ConsumerState<TransactionsScreen> {
   bool _isSearching = false;
 
   @override
+  void deactivate() {
+    // Clear filters and search when navigating away from the transactions tab.
+    // These providers are not autoDispose because the tab stays alive in
+    // StatefulShellRoute.indexedStack — so we reset them here to prevent
+    // stale filters from silently hiding transactions on return.
+    ref.read(transactionFiltersProvider.notifier).state =
+        TransactionFilters.empty;
+    ref.read(transactionSearchQueryProvider.notifier).state = '';
+    _searchController.clear();
+    if (_isSearching) {
+      _isSearching = false;
+    }
+    super.deactivate();
+  }
+
+  @override
   void dispose() {
     _searchController.dispose();
     super.dispose();


### PR DESCRIPTION
## Summary
- Clear `transactionFiltersProvider`, `transactionSearchQueryProvider`, and search UI state in `deactivate()` when the user navigates away from the transactions tab
- Prevents stale filters from silently hiding transactions when returning to the tab

## Root cause
The filter/search providers are plain `StateProvider` (not `.autoDispose`) because the transactions tab lives in `StatefulShellRoute.indexedStack` and never disposes. Switching tabs leaves orphaned filter state with no visual indicator.

## Test plan
- [ ] Open transactions tab, type a search query, switch to another tab, switch back — search bar should be closed and all transactions visible
- [ ] Open transactions tab, apply filters via the filter sheet, switch tabs, switch back — filter badge should be gone and all transactions visible
- [ ] `flutter analyze` passes
- [ ] Existing tests pass

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)