### PR TITLE
Fix Linux background sync no-op callback

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -157,7 +157,16 @@ class _BackgroundSyncInitializerState
       if (connections.isEmpty) return;
 
       final syncManager = ref.read(backgroundSyncManagerProvider);
-      await syncManager.register(syncCallback: () async {});
+      final syncService = ref.read(simplefinSyncServiceProvider);
+      final connRepo = ref.read(bankConnectionRepositoryProvider);
+
+      await syncManager.register(syncCallback: () async {
+        final conns = await connRepo.getAllConnections();
+        for (final conn in conns) {
+          if (conn.status != 'connected') continue;
+          await syncService.syncConnection(conn.id);
+        }
+      });
     } catch (e) {
       if (kDebugMode) debugPrint('Background sync registration failed: $e');
     }


### PR DESCRIPTION
## Summary
- Replace the empty `() async {}` sync callback with real logic that iterates all connected bank connections and calls `syncService.syncConnection()` for each
- On Android this callback is unused (WorkManager dispatches independently), but on Linux the `Timer.periodic` path relies on it entirely

## Root cause
`_BackgroundSyncInitializer._maybeRegisterSync()` passed an empty lambda to `syncManager.register()`. The Linux code path in `BackgroundSyncManager` calls this lambda inside `Timer.periodic`, so sync was silently doing nothing.

## Test plan
- [ ] On Linux: enable auto-sync with a connected SimpleFIN account, verify sync fires on the timer interval
- [ ] On Android: verify no behavioral change (WorkManager still handles sync independently)
- [ ] `flutter analyze` passes
- [ ] Existing tests pass

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)