### PR TITLE
Add CSV import for bulk payee-category rules

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -20,6 +20,7 @@ import '../../domain/usecases/categories/category_seeder.dart';
 import '../../domain/usecases/export/csv_export_service.dart';
 import '../../domain/usecases/import/csv_import_service.dart';
 import '../../domain/usecases/categorize/auto_categorize_service.dart';
+import '../../domain/usecases/categorize/rules_import_service.dart';
 import '../../domain/usecases/recurring/recurring_detection_service.dart';
 import '../../domain/usecases/ai/budget_suggestion_service.dart';
 import '../../domain/usecases/ai/chat_service.dart';
@@ -124,6 +125,13 @@ final autoCategorizeServiceProvider = Provider<AutoCategorizeService>((ref) {
   return AutoCategorizeService(
     ref.watch(autoCategorizeRepositoryProvider),
     ref.watch(transactionRepositoryProvider),
+  );
+});
+
+final rulesImportServiceProvider = Provider<RulesImportService>((ref) {
+  return RulesImportService(
+    ref.watch(autoCategorizeRepositoryProvider),
+    ref.watch(categoryRepositoryProvider),
   );
 });
 

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -22,6 +22,7 @@ import '../../presentation/features/recurring/recurring_screen.dart';
 import '../../presentation/features/import/csv_import_screen.dart';
 import '../../presentation/features/import/import_history_screen.dart';
 import '../../presentation/features/settings/auto_categorize_rules_screen.dart';
+import '../../presentation/features/import/import_rules_screen.dart';
 import '../../presentation/shared/widgets/app_shell.dart';
 import '../di/providers.dart';
 
@@ -50,6 +51,7 @@ class AppRoutes {
   static const String llmSettings = '/llm-settings';
   static const String aiChat = '/ai/chat';
   static const String autoCategorizeRules = '/auto-categorize-rules';
+  static const String importRules = '/auto-categorize-rules/import';
 }
 
 /// Navigator keys for each tab branch.
@@ -189,6 +191,13 @@ GoRouter createAppRouter(Ref ref) {
         path: AppRoutes.autoCategorizeRules,
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) => const AutoCategorizeRulesScreen(),
+      ),
+
+      // Import rules via CSV (full-screen)
+      GoRoute(
+        path: AppRoutes.importRules,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const ImportRulesScreen(),
       ),
 
       // LLM settings (full-screen)

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -50,6 +50,13 @@ class AutoCategorizeRepository {
         .watch();
   }
 
+  /// Get all rules (enabled and disabled), ordered by priority.
+  Future<List<AutoCategorizeRule>> getAllRules() {
+    return (_db.select(_db.autoCategorizeRules)
+          ..orderBy([(r) => OrderingTerm.asc(r.priority)]))
+        .get();
+  }
+
   /// Insert a single rule.
   Future<void> insertRule(AutoCategorizeRulesCompanion rule) {
     return _db.into(_db.autoCategorizeRules).insert(rule);

--- a/lib/domain/usecases/categorize/rules_import_service.dart
+++ b/lib/domain/usecases/categorize/rules_import_service.dart
@@ -1,0 +1,165 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:uuid/uuid.dart';
+
+import '../../../data/local/database/app_database.dart';
+import '../../../data/repositories/auto_categorize_repository.dart';
+import '../../../data/repositories/category_repository.dart';
+
+/// Result of a CSV rules import operation.
+class RulesImportResult {
+  const RulesImportResult({
+    required this.imported,
+    required this.skippedDuplicate,
+    required this.skippedCategoryNotFound,
+    required this.unknownCategories,
+  });
+
+  final int imported;
+  final int skippedDuplicate;
+  final int skippedCategoryNotFound;
+  final List<String> unknownCategories;
+}
+
+/// Imports auto-categorization rules from CSV content.
+///
+/// CSV format — two columns, optional header row:
+/// ```
+/// payee,category
+/// KROGER,Groceries
+/// MY LOCAL GYM,Gym & Fitness
+/// ```
+///
+/// Payees are uppercased and stored as `payeeContains`.
+/// Categories are matched by name (case-insensitive); parent wins on duplicates.
+class RulesImportService {
+  RulesImportService(this._autoCategorizeRepository, this._categoryRepository);
+
+  final AutoCategorizeRepository _autoCategorizeRepository;
+  final CategoryRepository _categoryRepository;
+
+  static const _uuid = Uuid();
+
+  Future<RulesImportResult> importFromCsv(String csvContent) async {
+    final rows = _parseCsv(csvContent);
+    if (rows.isEmpty) {
+      return const RulesImportResult(
+        imported: 0,
+        skippedDuplicate: 0,
+        skippedCategoryNotFound: 0,
+        unknownCategories: [],
+      );
+    }
+
+    // Auto-detect header: skip first row if it looks like a header.
+    final dataRows = _hasHeader(rows.first) ? rows.skip(1).toList() : rows;
+
+    // Build name → ID lookup (parents first so parent wins on duplicate names).
+    final categories = await _categoryRepository.getAllCategories();
+    final catByName = <String, String>{};
+    for (final c in categories.where((c) => c.parentId == null)) {
+      catByName.putIfAbsent(c.name.toLowerCase(), () => c.id);
+    }
+    for (final c in categories.where((c) => c.parentId != null)) {
+      catByName.putIfAbsent(c.name.toLowerCase(), () => c.id);
+    }
+
+    // Build set of existing payeeContains for dedup.
+    final existingRules = await _autoCategorizeRepository.getAllRules();
+    final existingPayees = <String>{
+      for (final r in existingRules)
+        if (r.payeeContains != null) r.payeeContains!,
+    };
+
+    // Find max priority among existing rules so new rules land above defaults.
+    final maxPriority =
+        existingRules.isEmpty ? -1 : existingRules.map((r) => r.priority).reduce((a, b) => a > b ? a : b);
+    var priority = maxPriority + 1;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final toInsert = <AutoCategorizeRulesCompanion>[];
+    var skippedDuplicate = 0;
+    var skippedCategoryNotFound = 0;
+    final unknownCategories = <String>[];
+
+    for (final row in dataRows) {
+      if (row.length < 2) continue;
+      final payee = row[0].trim().toUpperCase();
+      final categoryName = row[1].trim();
+      if (payee.isEmpty || categoryName.isEmpty) continue;
+
+      if (existingPayees.contains(payee)) {
+        skippedDuplicate++;
+        continue;
+      }
+
+      final categoryId = catByName[categoryName.toLowerCase()];
+      if (categoryId == null) {
+        skippedCategoryNotFound++;
+        if (!unknownCategories.contains(categoryName)) {
+          unknownCategories.add(categoryName);
+        }
+        continue;
+      }
+
+      existingPayees.add(payee); // prevent intra-batch duplicates
+      toInsert.add(AutoCategorizeRulesCompanion.insert(
+        id: _uuid.v4(),
+        name: '$payee → $categoryName',
+        priority: priority++,
+        categoryId: categoryId,
+        payeeContains: Value(payee),
+        isEnabled: const Value(true),
+        createdAt: now,
+        updatedAt: now,
+      ));
+    }
+
+    if (toInsert.isNotEmpty) {
+      await _autoCategorizeRepository.insertRules(toInsert);
+    }
+
+    return RulesImportResult(
+      imported: toInsert.length,
+      skippedDuplicate: skippedDuplicate,
+      skippedCategoryNotFound: skippedCategoryNotFound,
+      unknownCategories: unknownCategories,
+    );
+  }
+
+  /// Parse CSV content into rows of string values.
+  List<List<String>> _parseCsv(String content) {
+    final rows = <List<String>>[];
+    for (final line in content.split('\n')) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+      rows.add(_parseLine(trimmed));
+    }
+    return rows;
+  }
+
+  List<String> _parseLine(String line) {
+    final fields = <String>[];
+    final buffer = StringBuffer();
+    var inQuotes = false;
+    for (var i = 0; i < line.length; i++) {
+      final ch = line[i];
+      if (ch == '"') {
+        inQuotes = !inQuotes;
+      } else if (ch == ',' && !inQuotes) {
+        fields.add(buffer.toString().trim());
+        buffer.clear();
+      } else {
+        buffer.write(ch);
+      }
+    }
+    fields.add(buffer.toString().trim());
+    return fields;
+  }
+
+  bool _hasHeader(List<String> firstRow) {
+    if (firstRow.length < 2) return false;
+    final a = firstRow[0].toLowerCase();
+    final b = firstRow[1].toLowerCase();
+    return a.contains('payee') || b.contains('category');
+  }
+}

--- a/lib/presentation/features/import/import_rules_screen.dart
+++ b/lib/presentation/features/import/import_rules_screen.dart
@@ -1,0 +1,253 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/di/providers.dart';
+import '../../../domain/usecases/categorize/rules_import_service.dart';
+
+/// Two-step screen for importing auto-categorization rules from CSV.
+///
+/// Step 1 — paste CSV text or load from file.
+/// Step 2 — results summary (imported / skipped counts).
+class ImportRulesScreen extends ConsumerStatefulWidget {
+  const ImportRulesScreen({super.key});
+
+  @override
+  ConsumerState<ImportRulesScreen> createState() => _ImportRulesScreenState();
+}
+
+class _ImportRulesScreenState extends ConsumerState<ImportRulesScreen> {
+  final _controller = TextEditingController();
+  bool _isLoading = false;
+  RulesImportResult? _result;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickFile() async {
+    final picked = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['csv', 'txt'],
+    );
+    if (picked == null || picked.files.single.path == null) return;
+
+    final path = picked.files.single.path!;
+    final content = await File(path).readAsString();
+    setState(() => _controller.text = content);
+  }
+
+  Future<void> _import() async {
+    final csv = _controller.text.trim();
+    if (csv.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Paste or load a CSV first')),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final service = ref.read(rulesImportServiceProvider);
+      final result = await service.importFromCsv(csv);
+      setState(() => _result = result);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Import failed: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Import Category Rules')),
+      body: _result != null ? _ResultsView(result: _result!) : _InputView(
+        controller: _controller,
+        isLoading: _isLoading,
+        onPickFile: _pickFile,
+        onImport: _import,
+      ),
+    );
+  }
+}
+
+class _InputView extends StatelessWidget {
+  const _InputView({
+    required this.controller,
+    required this.isLoading,
+    required this.onPickFile,
+    required this.onImport,
+  });
+
+  final TextEditingController controller;
+  final bool isLoading;
+  final VoidCallback onPickFile;
+  final VoidCallback onImport;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Paste CSV or load a file. Two columns: payee, category.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Example:\npayee,category\nKROGER,Groceries\nMY LOCAL GYM,Gym',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: isLoading ? null : onPickFile,
+            icon: const Icon(Icons.folder_open),
+            label: const Text('Load from file'),
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              maxLines: null,
+              expands: true,
+              textAlignVertical: TextAlignVertical.top,
+              decoration: const InputDecoration(
+                hintText: 'payee,category\nKROGER,Groceries\n...',
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.all(12),
+              ),
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(fontFamily: 'monospace'),
+            ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: isLoading ? null : onImport,
+            child: isLoading
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Import Rules'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ResultsView extends StatelessWidget {
+  const _ResultsView({required this.result});
+
+  final RulesImportResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Icon(
+            result.imported > 0 ? Icons.check_circle : Icons.info_outline,
+            size: 48,
+            color: result.imported > 0 ? Colors.green : colorScheme.primary,
+          ),
+          const SizedBox(height: 16),
+          _CountRow(
+            label: 'Rules imported',
+            value: result.imported,
+            color: Colors.green,
+          ),
+          _CountRow(
+            label: 'Skipped (already exists)',
+            value: result.skippedDuplicate,
+          ),
+          _CountRow(
+            label: 'Skipped (category not found)',
+            value: result.skippedCategoryNotFound,
+            color: result.skippedCategoryNotFound > 0
+                ? colorScheme.error
+                : null,
+          ),
+          if (result.unknownCategories.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Text(
+              'Unknown categories — fix in your CSV:',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            ...result.unknownCategories.map(
+              (name) => Padding(
+                padding: const EdgeInsets.only(bottom: 2),
+                child: Text(
+                  '• $name',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.error,
+                        fontFamily: 'monospace',
+                      ),
+                ),
+              ),
+            ),
+          ],
+          const Spacer(),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Done'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CountRow extends StatelessWidget {
+  const _CountRow({required this.label, required this.value, this.color});
+
+  final String label;
+  final int value;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          Text(
+            '$value',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/features/settings/settings_screen.dart
+++ b/lib/presentation/features/settings/settings_screen.dart
@@ -126,6 +126,13 @@ class SettingsScreen extends ConsumerWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: () => context.push(AppRoutes.autoCategorizeRules),
           ),
+          ListTile(
+            leading: const Icon(Icons.upload_file),
+            title: const Text('Import Category Rules'),
+            subtitle: const Text('Bulk-add rules from a CSV file'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.importRules),
+          ),
 
           const Divider(),
 


### PR DESCRIPTION
## Summary
- New `RulesImportService` parses a two-column CSV (`payee,category`) and bulk-inserts auto-categorization rules, mirroring `RuleSeeder` logic (parent-wins category resolution, priority above existing defaults at 300+)
- New `ImportRulesScreen` offers paste-or-file-pick input, auto-detects header rows, and shows a results summary (imported / skipped duplicate / skipped unknown category)
- Entry point added to Settings → Categories & Rules → Import Category Rules
- `getAllRules()` added to `AutoCategorizeRepository` for complete dedup (including disabled rules)

## Test plan
- [ ] Navigate to Settings → Categories & Rules → Import Category Rules
- [ ] Paste a CSV with valid rows, a duplicate payee, and an unknown category name — verify counts are correct
- [ ] Load a `.csv` file using the file picker button — verify content populates the text area
- [ ] Verify imported rules appear in Settings → Auto-Categorization Rules list
- [ ] Verify imported rules apply on next bulk categorize run
- [ ] `flutter analyze` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)