### PR TITLE
Fix category picker not opening on physical Android

### DIFF
--- a/lib/presentation/features/recurring/add_edit_recurring_screen.dart
+++ b/lib/presentation/features/recurring/add_edit_recurring_screen.dart
@@ -88,30 +88,30 @@ class _AddEditRecurringScreenState
     }
   }
 
-  void _showCategoryPicker() {
-    final categoriesAsync = ref.read(allCategoriesProvider);
+  Future<void> _showCategoryPicker() async {
+    final categories = await ref.read(allCategoriesProvider.future);
 
-    categoriesAsync.whenData((categories) async {
-      final result = await showCategoryPickerSheet(
-        context: context,
-        categories: categories,
-        selectedCategoryId: _selectedCategoryId,
-      );
+    if (!mounted) return;
 
-      if (!mounted || result == null) return;
+    final result = await showCategoryPickerSheet(
+      context: context,
+      categories: categories,
+      selectedCategoryId: _selectedCategoryId,
+    );
 
-      if (result.cleared) {
-        setState(() {
-          _selectedCategoryId = null;
-          _selectedCategoryName = null;
-        });
-      } else {
-        setState(() {
-          _selectedCategoryId = result.id;
-          _selectedCategoryName = result.name;
-        });
-      }
-    });
+    if (!mounted || result == null) return;
+
+    if (result.cleared) {
+      setState(() {
+        _selectedCategoryId = null;
+        _selectedCategoryName = null;
+      });
+    } else {
+      setState(() {
+        _selectedCategoryId = result.id;
+        _selectedCategoryName = result.name;
+      });
+    }
   }
 
   Future<void> _save() async {

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -230,22 +230,23 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     );
   }
 
-  void _pickCategory(BuildContext context) {
-    final categoriesAsync = ref.read(allCategoriesProvider);
-    categoriesAsync.whenData((categories) async {
-      final result = await showCategoryPickerSheet(
-        context: context,
-        categories: categories,
-        selectedCategoryId: _selectedCategoryId,
-        showClear: false,
-      );
-      if (result != null && !result.cleared && mounted) {
-        setState(() {
-          _selectedCategoryId = result.id;
-          _selectedCategoryName = result.name;
-        });
-      }
-    });
+  Future<void> _pickCategory(BuildContext context) async {
+    final categories = await ref.read(allCategoriesProvider.future);
+
+    if (!mounted) return;
+
+    final result = await showCategoryPickerSheet(
+      context: context,
+      categories: categories,
+      selectedCategoryId: _selectedCategoryId,
+      showClear: false,
+    );
+    if (result != null && !result.cleared && mounted) {
+      setState(() {
+        _selectedCategoryId = result.id;
+        _selectedCategoryName = result.name;
+      });
+    }
   }
 
   void _save() {

--- a/lib/presentation/features/transactions/add_edit_transaction_screen.dart
+++ b/lib/presentation/features/transactions/add_edit_transaction_screen.dart
@@ -107,32 +107,34 @@ class _AddEditTransactionScreenState
     }
   }
 
-  void _showCategoryPicker() {
-    final categoriesAsync = _isExpense
-        ? ref.read(expenseCategoriesProvider)
-        : ref.read(incomeCategoriesProvider);
+  Future<void> _showCategoryPicker() async {
+    final categories = await ref.read(
+      _isExpense
+          ? expenseCategoriesProvider.future
+          : incomeCategoriesProvider.future,
+    );
 
-    categoriesAsync.whenData((categories) async {
-      final result = await showCategoryPickerSheet(
-        context: context,
-        categories: categories,
-        selectedCategoryId: _selectedCategoryId,
-      );
+    if (!mounted) return;
 
-      if (!mounted || result == null) return;
+    final result = await showCategoryPickerSheet(
+      context: context,
+      categories: categories,
+      selectedCategoryId: _selectedCategoryId,
+    );
 
-      if (result.cleared) {
-        setState(() {
-          _selectedCategoryId = null;
-          _selectedCategoryName = null;
-        });
-      } else {
-        setState(() {
-          _selectedCategoryId = result.id;
-          _selectedCategoryName = result.name;
-        });
-      }
-    });
+    if (!mounted || result == null) return;
+
+    if (result.cleared) {
+      setState(() {
+        _selectedCategoryId = null;
+        _selectedCategoryName = null;
+      });
+    } else {
+      setState(() {
+        _selectedCategoryId = result.id;
+        _selectedCategoryName = result.name;
+      });
+    }
   }
 
   Future<void> _save() async {

--- a/lib/presentation/features/transactions/widgets/filter_bottom_sheet.dart
+++ b/lib/presentation/features/transactions/widgets/filter_bottom_sheet.dart
@@ -70,30 +70,31 @@ class _FilterBottomSheetState extends ConsumerState<FilterBottomSheet> {
     }
   }
 
-  void _showCategoryPicker() {
-    final categoriesAsync = ref.read(allCategoriesProvider);
-    categoriesAsync.whenData((categories) async {
-      final result = await showCategoryPickerSheet(
-        context: context,
-        categories: categories,
-        selectedCategoryId: _filters.categoryId,
-        title: 'Filter by Category',
-      );
+  Future<void> _showCategoryPicker() async {
+    final categories = await ref.read(allCategoriesProvider.future);
 
-      if (!mounted || result == null) return;
+    if (!mounted) return;
 
-      if (result.cleared) {
-        setState(() {
-          _filters = _filters.copyWith(clearCategory: true);
-          _categoryName = null;
-        });
-      } else {
-        setState(() {
-          _filters = _filters.copyWith(categoryId: result.id);
-          _categoryName = result.name;
-        });
-      }
-    });
+    final result = await showCategoryPickerSheet(
+      context: context,
+      categories: categories,
+      selectedCategoryId: _filters.categoryId,
+      title: 'Filter by Category',
+    );
+
+    if (!mounted || result == null) return;
+
+    if (result.cleared) {
+      setState(() {
+        _filters = _filters.copyWith(clearCategory: true);
+        _categoryName = null;
+      });
+    } else {
+      setState(() {
+        _filters = _filters.copyWith(categoryId: result.id);
+        _categoryName = result.name;
+      });
+    }
   }
 
   void _showAccountPicker() {


### PR DESCRIPTION
## Summary
- **Bug**: Tapping category field on physical Android does nothing — works fine in emulator
- **Root cause**: `ref.read(streamProvider)` returns `AsyncLoading` when the autoDispose stream hasn't emitted yet. `whenData()` silently skips, so the bottom sheet never opens. Emulators have warmer provider caches due to faster I/O.
- **Fix**: Replace `ref.read(provider)` + `whenData` with `await ref.read(provider.future)` which properly waits for the first stream emission before showing the picker

All 4 category picker callsites fixed:
- `add_edit_transaction_screen.dart`
- `filter_bottom_sheet.dart`
- `add_edit_recurring_screen.dart`
- `auto_categorize_rules_screen.dart`

## Test plan
- [ ] Build debug APK and install on physical Android device
- [ ] Edit a transaction → tap Category → picker should open
- [ ] Add a transaction → tap Category → picker should open
- [ ] Filter transactions → tap Category filter → picker should open
- [ ] `flutter test` passes (175 tests, all green)
- [ ] `flutter analyze` clean (1 pre-existing info-level lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)