### PR TITLE
Fix SimpleFIN sync skipping accounts after reconnect

### DIFF
--- a/lib/data/repositories/account_repository.dart
+++ b/lib/data/repositories/account_repository.dart
@@ -211,6 +211,13 @@ class AccountRepository {
     ));
   }
 
+  /// Find an account by its external ID (regardless of which connection it belongs to).
+  Future<Account?> getAccountByExternalId(String externalId) {
+    return (_db.select(_db.accounts)
+          ..where((a) => a.externalId.equals(externalId)))
+        .getSingleOrNull();
+  }
+
   /// Get count of accounts.
   Future<int> getAccountCount() async {
     final count = _db.accounts.id.count();

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -204,16 +204,53 @@ class SimplefinSyncService {
       // Preload categorization rules once for the entire sync
       final rules = await _autoCategorizeService.loadEnabledRules();
 
+      // Load linked accounts once (same query for every SF account)
+      final linkedAccounts =
+          await _accountRepo.getAccountsByConnection(connectionId);
+
+      if (kDebugMode) {
+        debugPrint(
+          'SimpleFIN sync: ${linkedAccounts.length} accounts linked to '
+          'connection $connectionId, externalIds: '
+          '${linkedAccounts.map((a) => a.externalId).toList()}',
+        );
+      }
+
       // Process each account
       for (final sfAccount in response.accounts) {
-        // Find linked local account
-        final linkedAccounts =
-            await _accountRepo.getAccountsByConnection(connectionId);
-        final localAccount = linkedAccounts
+        // Find linked local account — first by connection, then fallback
+        var localAccount = linkedAccounts
             .where((a) => a.externalId == sfAccount.id)
             .firstOrNull;
 
-        if (localAccount == null) continue;
+        // Fallback: account may exist with correct externalId but wrong/null
+        // bankConnectionId (e.g. after disconnect/reconnect cycle)
+        if (localAccount == null) {
+          final fallback =
+              await _accountRepo.getAccountByExternalId(sfAccount.id);
+          if (fallback != null) {
+            // Auto-repair: re-associate account with current connection
+            await _accountRepo.linkToBank(
+                fallback.id, connectionId, sfAccount.id);
+            localAccount = fallback;
+            if (kDebugMode) {
+              debugPrint(
+                'SimpleFIN sync: repaired account "${fallback.name}" '
+                '(${fallback.id}) — re-linked to connection $connectionId',
+              );
+            }
+          }
+        }
+
+        if (localAccount == null) {
+          if (kDebugMode) {
+            debugPrint(
+              'SimpleFIN sync: no local account for SF account '
+              '"${sfAccount.name}" (externalId: ${sfAccount.id}) — skipping',
+            );
+          }
+          continue;
+        }
 
         // Update balance
         await _accountRepo.updateBalance(

--- a/test/unit/usecases/sync/simplefin_sync_service_test.dart
+++ b/test/unit/usecases/sync/simplefin_sync_service_test.dart
@@ -194,6 +194,8 @@ void main() {
         .thenAnswer((_) async => const SimplefinAccountsResponse(accounts: []));
     when(() => mockAutoCatService.loadEnabledRules())
         .thenAnswer((_) async => []);
+    when(() => mockAccountRepo.getAccountsByConnection(connectionId))
+        .thenAnswer((_) async => []);
     when(() => mockConnectionRepo.updateLastSyncedAt(any(), any()))
         .thenAnswer((_) async {});
     when(() => mockImportRepo.insertImportRecord(any()))
@@ -283,7 +285,8 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockTxnRepo.getByExternalId(any()))
           .thenAnswer((_) async => null);
-      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any()))
+      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
+            excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => false);
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
@@ -378,7 +381,8 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockTxnRepo.getByExternalId(any()))
           .thenAnswer((_) async => null);
-      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any()))
+      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
+            excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => true);
 
       when(() => mockClient.getAccounts(any(),
@@ -470,7 +474,8 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockTxnRepo.getByExternalId(any()))
           .thenAnswer((_) async => null);
-      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any()))
+      when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
+            excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => false);
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
@@ -508,6 +513,46 @@ void main() {
       await service.syncConnection(connectionId);
 
       verify(() => mockTxnRepo.updateCategory(any(), 'cat-dining')).called(1);
+    });
+
+    test('falls back to externalId match when bankConnectionId is wrong',
+        () async {
+      stubBasicSuccessfulSync();
+      // Account exists but linked to a different (old) connection
+      final orphanedAccount = makeAccount(bankConnectionId: 'old-conn');
+      when(() => mockAccountRepo.getAccountsByConnection(connectionId))
+          .thenAnswer((_) async => []); // not found by connection
+      when(() => mockAccountRepo.getAccountByExternalId('sf-acc-1'))
+          .thenAnswer((_) async => orphanedAccount);
+      when(() => mockAccountRepo.linkToBank(any(), any(), any()))
+          .thenAnswer((_) async {});
+      when(() => mockAccountRepo.updateBalance(any(), any()))
+          .thenAnswer((_) async {});
+      when(() => mockAccountRepo.updateLastSyncedAt(any()))
+          .thenAnswer((_) async {});
+
+      when(() => mockClient.getAccounts(any(),
+              startDate: any(named: 'startDate'),
+              includePending: any(named: 'includePending')))
+          .thenAnswer((_) async => const SimplefinAccountsResponse(
+                accounts: [
+                  SimplefinAccount(
+                    id: 'sf-acc-1',
+                    name: 'Checking',
+                    currency: 'USD',
+                    balanceCents: 250000,
+                    balanceDateUnix: 1700000000,
+                  ),
+                ],
+              ));
+
+      final result = await service.syncConnection(connectionId);
+
+      expect(result.accountsUpdated, 1);
+      // Verify it re-linked the account to the current connection
+      verify(() => mockAccountRepo.linkToBank(accountId, connectionId, 'sf-acc-1'))
+          .called(1);
+      verify(() => mockAccountRepo.updateBalance(accountId, 250000)).called(1);
     });
 
     test('records import history on success', () async {


### PR DESCRIPTION
## Summary

- SimpleFIN sync matched accounts solely by `bankConnectionId`, so after a disconnect/reconnect cycle (which nulls or changes the connection ID), all accounts were silently skipped — no balance updates, no transactions, no errors
- Added fallback: when connection-scoped lookup fails, search all accounts by `externalId` and auto-repair the `bankConnectionId` association
- Moved `getAccountsByConnection` query outside the per-account loop (was the same query every iteration)
- Added `kDebugMode` logging at account-match and skip points for future debugging

## Test plan

- [x] `flutter analyze` — no errors or warnings
- [x] `flutter test` — 201 tests pass (was 195+5 failures; fixed 5 pre-existing broken mock stubs)
- [x] New test: `falls back to externalId match when bankConnectionId is wrong`
- [ ] Deploy to device, run sync, confirm balances update and new transactions import
- [ ] Verify re-linking still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)