### PR TITLE
Hoist magic number 86400000 into AppConstants.millisecondsPerDay

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -22,6 +22,9 @@ class AppConstants {
   static const int maxDailySyncs = 24;
   static const int backgroundSyncIntervalHours = 8;
 
+  /// Time constants.
+  static const int millisecondsPerDay = 86400000;
+
   /// LLM rate limits.
   static const int maxLlmCallsPerDay = 50;
   static const int maxInsightsPerDay = 5;

--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 
+import '../../core/constants/app_constants.dart';
 import '../local/database/app_database.dart';
 
 /// Repository for transaction CRUD and query operations.
@@ -201,7 +202,7 @@ class TransactionRepository {
     int amountCents, {
     String? excludeExternalIdPrefix,
   }) async {
-    final windowMs = 86400000 * 3; // ±3 days
+    final windowMs = AppConstants.millisecondsPerDay * 3; // ±3 days
     final result = await (_db.select(_db.transactions)
           ..where((t) {
             var condition = t.accountId.equals(accountId) &

--- a/test/unit/repositories/transaction_repository_test.dart
+++ b/test/unit/repositories/transaction_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:patrimonium/core/constants/app_constants.dart';
 import 'package:patrimonium/data/local/database/app_database.dart';
 import 'package:patrimonium/data/repositories/transaction_repository.dart';
 
@@ -19,10 +20,10 @@ void main() {
 
   group('getTransactionSumsAfterDate', () {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final cutoffDate = now - 86400000 * 5; // 5 days ago
-    final beforeCutoff = cutoffDate - 86400000; // 6 days ago
-    final afterCutoff = cutoffDate + 86400000; // 4 days ago
-    final recentDate = now - 86400000; // 1 day ago
+    final cutoffDate = now - AppConstants.millisecondsPerDay * 5; // 5 days ago
+    final beforeCutoff = cutoffDate - AppConstants.millisecondsPerDay; // 6 days ago
+    final afterCutoff = cutoffDate + AppConstants.millisecondsPerDay; // 4 days ago
+    final recentDate = now - AppConstants.millisecondsPerDay; // 1 day ago
 
     Future<void> insertTxn(
         String id, String accountId, int amountCents, int date) async {
@@ -96,11 +97,11 @@ void main() {
 
   group('getTotalExpensesByCategoryIds', () {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final rangeStart = now - 86400000 * 30; // 30 days ago
+    final rangeStart = now - AppConstants.millisecondsPerDay * 30; // 30 days ago
     final rangeEnd = now;
-    final inRange = now - 86400000 * 15; // 15 days ago
-    final beforeRange = rangeStart - 86400000; // 31 days ago
-    final afterRange = rangeEnd + 86400000; // 1 day in future
+    final inRange = now - AppConstants.millisecondsPerDay * 15; // 15 days ago
+    final beforeRange = rangeStart - AppConstants.millisecondsPerDay; // 31 days ago
+    final afterRange = rangeEnd + AppConstants.millisecondsPerDay; // 1 day in future
 
     Future<void> insertTxn(
         String id, int amountCents, int date, String? categoryId) async {
@@ -190,7 +191,7 @@ void main() {
 
   group('existsByFuzzyMatch', () {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final baseDate = now - 86400000 * 10; // 10 days ago
+    final baseDate = now - AppConstants.millisecondsPerDay * 10; // 10 days ago
 
     Future<void> insertTxnWithExternalId(
       String id,
@@ -221,7 +222,7 @@ void main() {
       // Act — same amount, 1 day later
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
       );
 
@@ -236,7 +237,7 @@ void main() {
       // Act
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -600,
       );
 
@@ -251,7 +252,7 @@ void main() {
       // Act — 4 days later (outside window)
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000 * 4,
+        baseDate + AppConstants.millisecondsPerDay * 4,
         -500,
       );
 
@@ -273,7 +274,7 @@ void main() {
       // Act — new SimpleFIN transaction with same amount, 1 day later
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
         excludeExternalIdPrefix: 'conn-1:',
       );
@@ -296,7 +297,7 @@ void main() {
       // Act — SimpleFIN sync with same amount
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
         excludeExternalIdPrefix: 'conn-1:',
       );
@@ -318,7 +319,7 @@ void main() {
       // Act — SimpleFIN sync with same amount
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
         excludeExternalIdPrefix: 'conn-1:',
       );
@@ -340,7 +341,7 @@ void main() {
       // Act — SimpleFIN sync from connection "conn-1"
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
         excludeExternalIdPrefix: 'conn-1:',
       );
@@ -363,7 +364,7 @@ void main() {
       // Act — no prefix exclusion (e.g. called from CSV import)
       final result = await repo.existsByFuzzyMatch(
         'acc-1',
-        baseDate + 86400000,
+        baseDate + AppConstants.millisecondsPerDay,
         -500,
       );
 


### PR DESCRIPTION
## Summary
- Adds `AppConstants.millisecondsPerDay` constant (86400000)
- Replaces all raw `86400000` usages in `transaction_repository.dart` and its test file

Closes #96

## Test plan
- [x] `flutter analyze` clean
- [x] All 201 tests pass
- [x] `grep -r 86400000` confirms no raw usages remain outside the constant definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)