### PR TITLE
Escape SQL wildcards in LIKE prefix for existsByFuzzyMatch

### DIFF
--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -209,9 +209,15 @@ class TransactionRepository {
                 t.date.isBiggerOrEqualValue(dateMs - windowMs) &
                 t.date.isSmallerOrEqualValue(dateMs + windowMs);
             if (excludeExternalIdPrefix != null) {
+              final escaped = excludeExternalIdPrefix
+                  .replaceAll(r'\', r'\\')
+                  .replaceAll('%', r'\%')
+                  .replaceAll('_', r'\_');
               condition = condition &
                   (t.externalId.isNull() |
-                      t.externalId.like('$excludeExternalIdPrefix%').not());
+                      t.externalId
+                          .like('$escaped%', escapeChar: r'\')
+                          .not());
             }
             return condition;
           })

--- a/test/unit/repositories/transaction_repository_test.dart
+++ b/test/unit/repositories/transaction_repository_test.dart
@@ -370,5 +370,53 @@ void main() {
       // Assert — should match (no exclusion applied)
       expect(result, true);
     });
+
+    test('escapes SQL wildcards in excludeExternalIdPrefix', () async {
+      // Arrange — transaction with externalId that looks like it could match
+      // an unescaped LIKE pattern
+      await insertTxnWithExternalId(
+        't1',
+        'acc-1',
+        -500,
+        baseDate,
+        externalId: 'prefix_with%wildcards:txn-1',
+      );
+
+      // Act — prefix containing SQL wildcards % and _
+      // Without escaping, '%' in prefix would match anything
+      final result = await repo.existsByFuzzyMatch(
+        'acc-1',
+        baseDate + 86400000,
+        -500,
+        excludeExternalIdPrefix: 'prefix_with%wildcards:',
+      );
+
+      // Assert — the wildcards are escaped, so the LIKE treats them literally
+      // and correctly excludes this transaction (it does start with the literal prefix)
+      expect(result, false);
+    });
+
+    test('unescaped _ in prefix does not act as single-char wildcard',
+        () async {
+      // Arrange — 'x' matches '_' as wildcard but not as literal
+      await insertTxnWithExternalId(
+        't1',
+        'acc-1',
+        -500,
+        baseDate,
+        externalId: 'ax:txn-1',
+      );
+
+      // Act — prefix 'a_:' with literal underscore should NOT match 'ax:'
+      final result = await repo.existsByFuzzyMatch(
+        'acc-1',
+        baseDate + 86400000,
+        -500,
+        excludeExternalIdPrefix: 'a_:',
+      );
+
+      // Assert — 'ax:txn-1' does not start with literal 'a_:', so not excluded
+      expect(result, true);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Escapes `\`, `%`, and `_` in `excludeExternalIdPrefix` before passing to Drift's `.like()` with `escapeChar: '\'`
- Prevents prefix strings containing SQL wildcards from matching unintended rows
- Adds 2 tests: one for `%` in prefix, one for `_` as single-char wildcard

Closes #97

## Test plan
- [x] `flutter analyze` clean
- [x] All 201 tests pass (19 in transaction_repository_test including 2 new)
- [x] New tests verify wildcards are treated literally, not as SQL patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)