### PR TITLE
Batch external ID lookups in SimpleFIN sync

### DIFF
--- a/lib/data/repositories/transaction_repository.dart
+++ b/lib/data/repositories/transaction_repository.dart
@@ -229,6 +229,44 @@ class TransactionRepository {
     return result.isNotEmpty;
   }
 
+  /// Returns all externalIds for the given account that start with [prefix].
+  Future<Set<String>> getExternalIdsByPrefix(
+      String prefix, String accountId) async {
+    final escaped = prefix
+        .replaceAll(r'\', r'\\')
+        .replaceAll('%', r'\%')
+        .replaceAll('_', r'\_');
+    final query = _db.selectOnly(_db.transactions)
+      ..addColumns([_db.transactions.externalId])
+      ..where(_db.transactions.accountId.equals(accountId) &
+          _db.transactions.externalId.like('$escaped%', escapeChar: r'\'));
+    final rows = await query.get();
+    return rows
+        .map((row) => row.read(_db.transactions.externalId))
+        .whereType<String>()
+        .toSet();
+  }
+
+  /// Returns pending transactions for the given account with externalId
+  /// starting with [prefix], keyed by externalId.
+  Future<Map<String, Transaction>> getPendingByPrefix(
+      String prefix, String accountId) async {
+    final escaped = prefix
+        .replaceAll(r'\', r'\\')
+        .replaceAll('%', r'\%')
+        .replaceAll('_', r'\_');
+    final query = _db.select(_db.transactions)
+      ..where((t) =>
+          t.accountId.equals(accountId) &
+          t.externalId.like('$escaped%', escapeChar: r'\') &
+          t.isPending.equals(true));
+    final rows = await query.get();
+    return {
+      for (final t in rows)
+        if (t.externalId != null) t.externalId!: t
+    };
+  }
+
   /// Get count of uncategorized transactions.
   Future<int> getUncategorizedCount() async {
     final count = _db.transactions.id.count();

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -260,24 +260,27 @@ class SimplefinSyncService {
         await _accountRepo.updateLastSyncedAt(localAccount.id);
         accountsUpdated++;
 
-        // Process transactions
+        // Process transactions — batch-load known IDs to avoid N+1 queries
         final externalIdPrefix = '$connectionId:';
+        final knownIds = await _transactionRepo.getExternalIdsByPrefix(
+            externalIdPrefix, localAccount.id);
+        final pendingTxns = await _transactionRepo.getPendingByPrefix(
+            externalIdPrefix, localAccount.id);
+
         for (final sfTxn in sfAccount.transactions) {
           final externalId = '$externalIdPrefix${sfTxn.id}';
 
-          // Check for existing transaction
-          final existing =
-              await _transactionRepo.getByExternalId(externalId);
-
-          if (existing != null) {
+          // Check for existing transaction (O(1) set lookup)
+          if (knownIds.contains(externalId)) {
             // When a pending transaction posts, update amount/date/description
             // (banks often adjust these when a pending charge clears)
-            if (existing.isPending && !sfTxn.isPending) {
+            final pendingTxn = pendingTxns[externalId];
+            if (pendingTxn != null && !sfTxn.isPending) {
               final dateUnixExisting =
                   sfTxn.transactedAtUnix ?? sfTxn.postedUnix;
               await _transactionRepo.updateTransaction(
                 TransactionsCompanion(
-                  id: Value(existing.id),
+                  id: Value(pendingTxn.id),
                   amountCents: Value(sfTxn.amountCents),
                   date: Value(dateUnixExisting * 1000),
                   payee: Value(sfTxn.description),

--- a/test/unit/usecases/sync/simplefin_sync_service_test.dart
+++ b/test/unit/usecases/sync/simplefin_sync_service_test.dart
@@ -196,6 +196,10 @@ void main() {
         .thenAnswer((_) async => []);
     when(() => mockAccountRepo.getAccountsByConnection(connectionId))
         .thenAnswer((_) async => []);
+    when(() => mockTxnRepo.getExternalIdsByPrefix(any(), any()))
+        .thenAnswer((_) async => {});
+    when(() => mockTxnRepo.getPendingByPrefix(any(), any()))
+        .thenAnswer((_) async => {});
     when(() => mockConnectionRepo.updateLastSyncedAt(any(), any()))
         .thenAnswer((_) async {});
     when(() => mockImportRepo.insertImportRecord(any()))
@@ -283,8 +287,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAccountRepo.updateLastSyncedAt(any()))
           .thenAnswer((_) async {});
-      when(() => mockTxnRepo.getByExternalId(any()))
-          .thenAnswer((_) async => null);
       when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
             excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => false);
@@ -335,10 +337,11 @@ void main() {
       when(() => mockAccountRepo.updateLastSyncedAt(any()))
           .thenAnswer((_) async {});
 
-      // Existing non-pending transaction
-      when(() => mockTxnRepo.getByExternalId('$connectionId:sf-txn-1'))
-          .thenAnswer(
-              (_) async => makeTransaction(id: 'existing-1', isPending: false));
+      // Batch lookup returns the existing externalId
+      when(() => mockTxnRepo.getExternalIdsByPrefix(any(), any()))
+          .thenAnswer((_) async => {'$connectionId:sf-txn-1'});
+      when(() => mockTxnRepo.getPendingByPrefix(any(), any()))
+          .thenAnswer((_) async => {});
 
       when(() => mockClient.getAccounts(any(),
               startDate: any(named: 'startDate'),
@@ -379,8 +382,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAccountRepo.updateLastSyncedAt(any()))
           .thenAnswer((_) async {});
-      when(() => mockTxnRepo.getByExternalId(any()))
-          .thenAnswer((_) async => null);
       when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
             excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => true);
@@ -425,10 +426,12 @@ void main() {
       when(() => mockAccountRepo.updateLastSyncedAt(any()))
           .thenAnswer((_) async {});
 
-      // Existing pending transaction
-      when(() => mockTxnRepo.getByExternalId('$connectionId:sf-txn-1'))
-          .thenAnswer((_) async =>
-              makeTransaction(id: 'existing-1', isPending: true));
+      // Existing pending transaction — returned by batch lookups
+      final pendingTxn = makeTransaction(id: 'existing-1', isPending: true);
+      when(() => mockTxnRepo.getExternalIdsByPrefix(any(), any()))
+          .thenAnswer((_) async => {'$connectionId:sf-txn-1'});
+      when(() => mockTxnRepo.getPendingByPrefix(any(), any())).thenAnswer(
+          (_) async => {'$connectionId:sf-txn-1': pendingTxn});
       when(() => mockTxnRepo.updateTransaction(any()))
           .thenAnswer((_) async => true);
 
@@ -472,8 +475,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAccountRepo.updateLastSyncedAt(any()))
           .thenAnswer((_) async {});
-      when(() => mockTxnRepo.getByExternalId(any()))
-          .thenAnswer((_) async => null);
       when(() => mockTxnRepo.existsByFuzzyMatch(any(), any(), any(),
             excludeExternalIdPrefix: any(named: 'excludeExternalIdPrefix')))
           .thenAnswer((_) async => false);


### PR DESCRIPTION
## Summary
- Adds `getExternalIdsByPrefix()` → `Set<String>` and `getPendingByPrefix()` → `Map<String, Transaction>` to TransactionRepository
- Refactors SimpleFIN sync loop to call these two queries once per account instead of `getByExternalId()` per transaction (N+1 → 2 queries)
- Both new methods escape SQL wildcards in the LIKE prefix
- Updates all sync service test mocks to use the new batch methods

Closes #98

## Test plan
- [x] `flutter analyze` clean
- [x] All 201 tests pass (23 sync service tests updated and passing)
- [x] Verified skip, insert, fuzzy-match, and pending→posted paths all work with batch lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)