### PR TITLE
feat(categorize): phase 1 auto-categorization improvements

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -40,7 +40,7 @@ class DefaultCategories {
 
   static const List<Map<String, dynamic>> expense = [
     {'name': 'Housing', 'icon': 'home', 'color': 0xFF5C6BC0, 'children': ['Rent/Mortgage', 'Utilities', 'Maintenance', 'Insurance']},
-    {'name': 'Transportation', 'icon': 'directions_car', 'color': 0xFF42A5F5, 'children': ['Gas', 'Auto Payment', 'Auto Insurance', 'Parking', 'Public Transit']},
+    {'name': 'Transportation', 'icon': 'directions_car', 'color': 0xFF42A5F5, 'children': ['Gas', 'Auto Payment', 'Auto Insurance', 'Auto Maintenance', 'Parking', 'Public Transit']},
     {'name': 'Groceries', 'icon': 'shopping_cart', 'color': 0xFF66BB6A, 'children': <String>[]},
     {'name': 'Dining', 'icon': 'restaurant', 'color': 0xFFEF5350, 'children': ['Restaurants', 'Coffee Shops', 'Fast Food', 'Delivery']},
     {'name': 'Shopping', 'icon': 'shopping_bag', 'color': 0xFFAB47BC, 'children': ['Clothing', 'Electronics', 'Home Goods']},

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -90,6 +90,27 @@ class AutoCategorizeRepository {
     });
   }
 
+  /// Retarget multiple rules' categoryId in a single batched transaction.
+  /// Used by RuleSeeder's one-shot retargets so a mid-loop failure can't
+  /// leave the table partially updated.
+  Future<void> updateRulesCategoryBatch(
+    Map<String, String> ruleIdToCategoryId,
+    int updatedAt,
+  ) {
+    return _db.batch((batch) {
+      for (final entry in ruleIdToCategoryId.entries) {
+        batch.update(
+          _db.autoCategorizeRules,
+          AutoCategorizeRulesCompanion(
+            categoryId: Value(entry.value),
+            updatedAt: Value(updatedAt),
+          ),
+          where: (r) => r.id.equals(entry.key),
+        );
+      }
+    });
+  }
+
   /// Check if any rules exist.
   Future<bool> hasRules() async {
     final count = _db.autoCategorizeRules.id.count();

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -302,6 +302,9 @@ class AutoCategorizeService {
       // Side effect: the categoryId on the saved transaction (user's literal
       // choice) and the cached categoryId (learned winner) can diverge. That
       // is intentional — the cache only influences *future* matches.
+      assert(existing.useCount >= 1,
+          'PayeeCategoryCache.useCount must be >= 1 per schema default; '
+          'got ${existing.useCount}');
       final penalized = existing.useCount - 1;
       if (penalized >= 1) {
         final newConfidence = min(1.0, 0.5 + (penalized * 0.1));

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -293,15 +293,37 @@ class AutoCategorizeService {
         updatedAt: Value(now),
       ));
     } else {
-      // Different category — user is correcting; reset
-      await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
-        payeeNormalized: Value(normalized),
-        categoryId: Value(categoryId),
-        confidence: const Value(0.5),
-        source: const Value('user'),
-        useCount: const Value(1),
-        updatedAt: Value(now),
-      ));
+      // Different category — penalize one step, do NOT wipe. A useCount of N
+      // requires N corrections to flip. A single misclick demotes the entry
+      // by 1; the previously-learned category is preserved unless its weight
+      // falls to zero. This protects the minimum-threshold (useCount=3)
+      // entry from being wiped by a single fat-finger.
+      //
+      // Side effect: the categoryId on the saved transaction (user's literal
+      // choice) and the cached categoryId (learned winner) can diverge. That
+      // is intentional — the cache only influences *future* matches.
+      final penalized = existing.useCount - 1;
+      if (penalized >= 1) {
+        final newConfidence = min(1.0, 0.5 + (penalized * 0.1));
+        await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
+          payeeNormalized: Value(normalized),
+          categoryId: Value(existing.categoryId),
+          confidence: Value(newConfidence),
+          source: const Value('user'),
+          useCount: Value(penalized),
+          updatedAt: Value(now),
+        ));
+      } else {
+        // useCount was 1; nothing left to keep — adopt the new category.
+        await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
+          payeeNormalized: Value(normalized),
+          categoryId: Value(categoryId),
+          confidence: const Value(0.5),
+          source: const Value('user'),
+          useCount: const Value(1),
+          updatedAt: Value(now),
+        ));
+      }
     }
 
     // Log correction if the category actually changed

--- a/lib/domain/usecases/categorize/default_rules_data.dart
+++ b/lib/domain/usecases/categorize/default_rules_data.dart
@@ -127,7 +127,8 @@ const defaultMerchantMappings = <(String, String)>[
   ('QUIKTRIP', 'Gas'),
   ('PILOT', 'Gas'),
   ('FLYING J', 'Gas'),
-  ('LOVE', 'Gas'),
+  ('LOVES TRAVEL', 'Gas'),
+  ("LOVE'S TRAVEL", 'Gas'),
   ('VALERO', 'Gas'),
   ('CITGO', 'Gas'),
   ('PHILLIPS 66', 'Gas'),
@@ -158,20 +159,20 @@ const defaultMerchantMappings = <(String, String)>[
   // -------------------------------------------------------------------------
   // Transportation → Auto Maintenance
   // -------------------------------------------------------------------------
-  ('JIFFY LUBE', 'Transportation'),
-  ('VALVOLINE', 'Transportation'),
-  ('FIRESTONE', 'Transportation'),
-  ('AUTOZONE', 'Transportation'),
-  ('PEP BOYS', 'Transportation'),
-  ("O'REILLY", 'Transportation'),
-  ('ADVANCE AUTO', 'Transportation'),
-  ('NAPA AUTO', 'Transportation'),
-  ('MIDAS', 'Transportation'),
-  ('GOODYEAR', 'Transportation'),
-  ('DISCOUNT TIRE', 'Transportation'),
-  ('MAACO', 'Transportation'),
-  ('MEINEKE', 'Transportation'),
-  ('SAFELITE', 'Transportation'),
+  ('JIFFY LUBE', 'Auto Maintenance'),
+  ('VALVOLINE', 'Auto Maintenance'),
+  ('FIRESTONE', 'Auto Maintenance'),
+  ('AUTOZONE', 'Auto Maintenance'),
+  ('PEP BOYS', 'Auto Maintenance'),
+  ("O'REILLY", 'Auto Maintenance'),
+  ('ADVANCE AUTO', 'Auto Maintenance'),
+  ('NAPA AUTO', 'Auto Maintenance'),
+  ('MIDAS', 'Auto Maintenance'),
+  ('GOODYEAR', 'Auto Maintenance'),
+  ('DISCOUNT TIRE', 'Auto Maintenance'),
+  ('MAACO', 'Auto Maintenance'),
+  ('MEINEKE', 'Auto Maintenance'),
+  ('SAFELITE', 'Auto Maintenance'),
 
   // -------------------------------------------------------------------------
   // Entertainment → Subscriptions
@@ -414,6 +415,79 @@ const defaultMerchantMappings = <(String, String)>[
   ('LIBERTY MUTUAL', 'Insurance'),
   ('NATIONWIDE', 'Insurance'),
   ('FARMERS INS', 'Insurance'),
+
+  // -------------------------------------------------------------------------
+  // 2025-era additions (curated; see plan for excluded entries)
+  // -------------------------------------------------------------------------
+
+  // EV charging → Gas
+  ('TESLA SUPERCHARGER', 'Gas'),
+  ('TESLA CHARGING', 'Gas'),
+  ('ELECTRIFY AMERICA', 'Gas'),
+  ('EVGO', 'Gas'),
+  ('CHARGEPOINT', 'Gas'),
+  ('BLINK CHARGING', 'Gas'),
+
+  // Telehealth → Medical
+  ('TELADOC', 'Medical'),
+  ('BETTERHELP', 'Medical'),
+  ('TALKSPACE', 'Medical'),
+  ('HIMS', 'Medical'),
+  ('HERS', 'Medical'),
+  ('RO HEALTH', 'Medical'),
+
+  // Modern Subscriptions
+  ('SUBSTACK', 'Subscriptions'),
+  ('PATREON', 'Subscriptions'),
+  ('MAX.COM', 'Subscriptions'),
+  ('HBO MAX', 'Subscriptions'),
+  ('GITHUB', 'Subscriptions'),
+  ('CHATGPT', 'Subscriptions'),
+  ('ANTHROPIC', 'Subscriptions'),
+  ('CLAUDE.AI', 'Subscriptions'),
+  ('PERPLEXITY', 'Subscriptions'),
+  ('1PASSWORD', 'Subscriptions'),
+  ('LASTPASS', 'Subscriptions'),
+  ('PROTON', 'Subscriptions'),
+  ('NORDVPN', 'Subscriptions'),
+  ('EXPRESSVPN', 'Subscriptions'),
+
+  // Public Transit (micromobility)
+  ('LIME', 'Public Transit'),
+  ('BIRD RIDES', 'Public Transit'), // bare 'BIRD' too generic
+  ('CITI BIKE', 'Public Transit'),
+  ('REVEL', 'Public Transit'),
+
+  // Groceries — specific warehouse strings (bare 'COSTCO' would match COSTCO GAS)
+  ('COSTCO WHSE', 'Groceries'),
+  ('COSTCO WHOLESALE', 'Groceries'),
+  ("SAM'S CLUB", 'Groceries'),
+  ('SAMS CLUB', 'Groceries'),
+  ('GOPUFF', 'Groceries'),
+  ('THRIVE MARKET', 'Groceries'),
+  ('MISFITS MARKET', 'Groceries'),
+  ('IMPERFECT FOODS', 'Groceries'),
+
+  // Delivery
+  ('CAVIAR', 'Delivery'),
+  ('CHOWNOW', 'Delivery'),
+
+  // Clothing
+  ('SHEIN', 'Clothing'),
+  ('ZAPPOS', 'Clothing'),
+  ('REI CO-OP', 'Clothing'), // bare 'REI' too generic
+  ('PATAGONIA', 'Clothing'),
+
+  // Coffee Shops
+  ('BLACK ROCK COFFEE', 'Coffee Shops'),
+  ('BIGGBY', 'Coffee Shops'),
+
+  // Restaurants (modern chains)
+  ('SWEETGREEN', 'Restaurants'),
+  ('CAVA', 'Restaurants'),
+  ('SHAKE SHACK', 'Restaurants'),
+  ('MOD PIZZA', 'Restaurants'),
+  ('BLAZE PIZZA', 'Restaurants'),
 ];
 
 /// Investment account transaction rules (matched by account type).

--- a/lib/domain/usecases/categorize/rule_conflicts.dart
+++ b/lib/domain/usecases/categorize/rule_conflicts.dart
@@ -1,0 +1,97 @@
+import '../../../data/local/database/app_database.dart';
+
+/// Kinds of conflicts that can arise when creating/editing an auto-categorize
+/// rule. All conflicts are warnings — save is never blocked.
+enum RuleConflictKind {
+  /// Another rule has the same effective payee pattern but maps to a
+  /// different category. Whichever has lower priority wins, which can
+  /// surprise the user.
+  samePatternDifferentCategory,
+
+  /// This rule's match set covers another rule's match set, and this rule
+  /// has equal-or-higher priority. The other rule would never run.
+  shadowsOther,
+
+  /// Another rule's match set covers this rule's match set, and the other
+  /// rule has equal-or-higher priority. This rule would never run.
+  shadowedByOther,
+}
+
+class RuleConflict {
+  const RuleConflict({required this.kind, required this.other});
+  final RuleConflictKind kind;
+  final AutoCategorizeRule other;
+}
+
+/// Detect conflicts between a proposed rule and the set of existing rules.
+///
+/// Only payee-pattern conflicts are detected. Rules with both `payeeExact`
+/// and `payeeContains` null (amount-range or account-type only) are skipped
+/// — checking those would require modeling the full match space and isn't
+/// worth the complexity for a warning-only UI affordance.
+///
+/// `editingRuleId` is the id of the rule being edited (so self-conflicts
+/// are filtered out); null when creating a new rule.
+List<RuleConflict> detectRuleConflicts({
+  required String? editingRuleId,
+  required String? payeeContains,
+  required String? payeeExact,
+  required String? categoryId,
+  required int priority,
+  required List<AutoCategorizeRule> existingRules,
+}) {
+  final rPc = (payeeContains == null || payeeContains.isEmpty)
+      ? null
+      : payeeContains.toUpperCase();
+  final rPe = (payeeExact == null || payeeExact.isEmpty)
+      ? null
+      : payeeExact.toUpperCase();
+  final rEffective = rPe ?? rPc;
+  if (rEffective == null || categoryId == null) return const [];
+
+  final conflicts = <RuleConflict>[];
+
+  for (final q in existingRules) {
+    if (q.id == editingRuleId) continue;
+    final qPc = q.payeeContains?.toUpperCase();
+    final qPe = q.payeeExact?.toUpperCase();
+    final qEffective = qPe ?? qPc;
+    if (qEffective == null) continue;
+
+    if (qEffective == rEffective && q.categoryId != categoryId) {
+      conflicts.add(
+        RuleConflict(kind: RuleConflictKind.samePatternDifferentCategory, other: q),
+      );
+      continue;
+    }
+
+    if (priority <= q.priority && _aShadowsB(rPc, rPe, qPc, qPe)) {
+      conflicts.add(RuleConflict(kind: RuleConflictKind.shadowsOther, other: q));
+      continue;
+    }
+
+    if (priority >= q.priority && _aShadowsB(qPc, qPe, rPc, rPe)) {
+      conflicts.add(
+        RuleConflict(kind: RuleConflictKind.shadowedByOther, other: q),
+      );
+      continue;
+    }
+  }
+
+  return conflicts;
+}
+
+/// Whether rule A's match set strictly contains rule B's match set.
+///
+/// Case combos:
+///   A exact, B exact      → never strict superset (only equal at most)
+///   A contains, B contains→ A⊃B iff B's pattern strictly contains A's pattern
+///   A contains, B exact   → A⊃B iff B's exact string strictly contains A's contains pattern
+///   A exact, B contains   → A⊃B never (B's set is unbounded)
+bool _aShadowsB(String? aPc, String? aPe, String? bPc, String? bPe) {
+  if (aPe != null) return false;
+  if (aPc == null) return false;
+  final bStr = bPe ?? bPc;
+  if (bStr == null) return false;
+  return bStr != aPc && bStr.contains(aPc);
+}

--- a/lib/domain/usecases/categorize/rule_conflicts.dart
+++ b/lib/domain/usecases/categorize/rule_conflicts.dart
@@ -40,12 +40,17 @@ List<RuleConflict> detectRuleConflicts({
   required int priority,
   required List<AutoCategorizeRule> existingRules,
 }) {
-  final rPc = (payeeContains == null || payeeContains.isEmpty)
+  // Trim first so whitespace-only patterns are treated as empty (otherwise
+  // '   '.toUpperCase() becomes a literal three-space pattern and matches
+  // weird things).
+  final pcTrimmed = payeeContains?.trim();
+  final peTrimmed = payeeExact?.trim();
+  final rPc = (pcTrimmed == null || pcTrimmed.isEmpty)
       ? null
-      : payeeContains.toUpperCase();
-  final rPe = (payeeExact == null || payeeExact.isEmpty)
+      : pcTrimmed.toUpperCase();
+  final rPe = (peTrimmed == null || peTrimmed.isEmpty)
       ? null
-      : payeeExact.toUpperCase();
+      : peTrimmed.toUpperCase();
   final rEffective = rPe ?? rPc;
   if (rEffective == null || categoryId == null) return const [];
 

--- a/lib/domain/usecases/categorize/rule_seeder.dart
+++ b/lib/domain/usecases/categorize/rule_seeder.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../data/local/database/app_database.dart';
@@ -99,7 +100,10 @@ class RuleSeeder {
   /// grows, the next startup inserts only the new entries. User-created rules
   /// with identical payeeContains are respected (skipped).
   Future<bool> _backfillMissingDefaultRules() async {
-    final existingRules = await _autoCatRepo.getEnabledRules();
+    // Use getAllRules (not getEnabledRules) so user-disabled rules also
+    // dedupe — otherwise re-seeding would insert duplicates next to the
+    // user's disabled rows.
+    final existingRules = await _autoCatRepo.getAllRules();
 
     String key(String payeeContains, String? accountType) =>
         '${payeeContains.toUpperCase()}|${accountType ?? ''}';
@@ -132,10 +136,14 @@ class RuleSeeder {
     final now = DateTime.now().millisecondsSinceEpoch;
     var priority = existingRules.length;
     final rules = <AutoCategorizeRulesCompanion>[];
+    final skipped = <String>[];
 
     for (final (payeeContains, categoryName) in missingGeneral) {
       final categoryId = catByName[categoryName];
-      if (categoryId == null) continue;
+      if (categoryId == null) {
+        skipped.add('$payeeContains → $categoryName');
+        continue;
+      }
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName',
@@ -150,7 +158,10 @@ class RuleSeeder {
 
     for (final (payeeContains, categoryName, accountType) in missingInvestment) {
       final categoryId = catByName[categoryName];
-      if (categoryId == null) continue;
+      if (categoryId == null) {
+        skipped.add('$payeeContains → $categoryName ($accountType)');
+        continue;
+      }
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName ($accountType)',
@@ -162,6 +173,14 @@ class RuleSeeder {
         createdAt: now,
         updatedAt: now,
       ));
+    }
+
+    if (kDebugMode && skipped.isNotEmpty) {
+      debugPrint(
+        'RuleSeeder: skipped ${skipped.length} default rule(s) — '
+        'target category not seeded: ${skipped.take(5).join(', ')}'
+        '${skipped.length > 5 ? ' …' : ''}',
+      );
     }
 
     if (rules.isEmpty) return false;
@@ -194,12 +213,19 @@ class RuleSeeder {
       }
     }
     if (transportationParentId == null || autoMaintenanceId == null) {
+      if (kDebugMode && transportationParentId != null) {
+        debugPrint(
+          'RuleSeeder: Auto Maintenance subcategory not yet seeded; '
+          'retarget skipped this launch',
+        );
+      }
       return false;
     }
 
-    final rules = await _autoCatRepo.getEnabledRules();
-    final now = DateTime.now().millisecondsSinceEpoch;
-    var retargetCount = 0;
+    // Use getAllRules so user-disabled rules also get retargeted — if they
+    // re-enable later they should map to the correct subcategory.
+    final rules = await _autoCatRepo.getAllRules();
+    final retargets = <String, String>{};
     for (final r in rules) {
       if (r.payeeContains == null) continue;
       if (!autoMaintenancePayees.contains(r.payeeContains!.toUpperCase())) {
@@ -207,17 +233,16 @@ class RuleSeeder {
       }
       if (r.categoryId != transportationParentId) continue;
       if (r.updatedAt != r.createdAt) continue; // user-edited; leave alone
-
-      await _autoCatRepo.updateRule(
-        AutoCategorizeRulesCompanion(
-          id: Value(r.id),
-          categoryId: Value(autoMaintenanceId),
-          updatedAt: Value(now),
-        ),
-      );
-      retargetCount++;
+      retargets[r.id] = autoMaintenanceId;
     }
 
-    return retargetCount > 0;
+    if (retargets.isEmpty) return false;
+
+    // Batch the updates so a mid-loop failure can't leave partial state.
+    await _autoCatRepo.updateRulesCategoryBatch(
+      retargets,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    return true;
   }
 }

--- a/lib/domain/usecases/categorize/rule_seeder.dart
+++ b/lib/domain/usecases/categorize/rule_seeder.dart
@@ -24,7 +24,9 @@ class RuleSeeder {
   /// Returns true if rules were seeded.
   Future<bool> seedIfEmpty() async {
     if (await _autoCatRepo.hasRules()) {
-      return _backfillInvestmentRules();
+      final backfilled = await _backfillMissingDefaultRules();
+      final retargeted = await _retargetAutoMaintenanceRules();
+      return backfilled || retargeted;
     }
 
     final categories = await _categoryRepo.getAllCategories();
@@ -89,31 +91,41 @@ class RuleSeeder {
     return true;
   }
 
-  /// Backfill missing investment rules for existing users.
+  /// Backfill any default rules missing for existing users — both the
+  /// general merchant rules and the investment-scoped rules.
   ///
-  /// Uses set-based dedup: builds a set of existing (payeeContains, accountType)
-  /// combos and only inserts rules that don't already exist. This is
-  /// self-healing — any time investmentMerchantMappings grows, the next
-  /// startup backfills only the missing entries.
-  Future<bool> _backfillInvestmentRules() async {
+  /// Uses set-based dedup on `(payeeContains|accountType)` signatures so it's
+  /// self-healing: any time defaultMerchantMappings or investmentMerchantMappings
+  /// grows, the next startup inserts only the new entries. User-created rules
+  /// with identical payeeContains are respected (skipped).
+  Future<bool> _backfillMissingDefaultRules() async {
     final existingRules = await _autoCatRepo.getEnabledRules();
 
-    // Build set of existing investment rule signatures
-    final existingKeys = <String>{};
-    for (final r in existingRules) {
-      if (r.accountType != null && r.payeeContains != null) {
-        existingKeys.add('${r.payeeContains!.toUpperCase()}|${r.accountType}');
-      }
-    }
+    String key(String payeeContains, String? accountType) =>
+        '${payeeContains.toUpperCase()}|${accountType ?? ''}';
 
-    // Check which mappings are missing before loading categories
-    final missing = investmentMerchantMappings.where((m) =>
-        !existingKeys.contains('${m.$1.toUpperCase()}|${m.$3}'));
-    if (missing.isEmpty) return false;
+    final existingKeys = <String>{
+      for (final r in existingRules)
+        if (r.payeeContains != null) key(r.payeeContains!, r.accountType),
+    };
+
+    final missingGeneral = [
+      for (final m in defaultMerchantMappings)
+        if (!existingKeys.contains(key(m.$1, null))) m,
+    ];
+    final missingInvestment = [
+      for (final m in investmentMerchantMappings)
+        if (!existingKeys.contains(key(m.$1, m.$3))) m,
+    ];
+
+    if (missingGeneral.isEmpty && missingInvestment.isEmpty) return false;
 
     final categories = await _categoryRepo.getAllCategories();
     final catByName = <String, String>{};
-    for (final c in categories) {
+    for (final c in categories.where((c) => c.parentId == null)) {
+      catByName.putIfAbsent(c.name, () => c.id);
+    }
+    for (final c in categories.where((c) => c.parentId != null)) {
       catByName.putIfAbsent(c.name, () => c.id);
     }
 
@@ -121,10 +133,24 @@ class RuleSeeder {
     var priority = existingRules.length;
     final rules = <AutoCategorizeRulesCompanion>[];
 
-    for (final (payeeContains, categoryName, accountType) in missing) {
+    for (final (payeeContains, categoryName) in missingGeneral) {
       final categoryId = catByName[categoryName];
       if (categoryId == null) continue;
+      rules.add(AutoCategorizeRulesCompanion.insert(
+        id: _uuid.v4(),
+        name: '$payeeContains → $categoryName',
+        priority: priority++,
+        categoryId: categoryId,
+        payeeContains: Value(payeeContains),
+        isEnabled: const Value(true),
+        createdAt: now,
+        updatedAt: now,
+      ));
+    }
 
+    for (final (payeeContains, categoryName, accountType) in missingInvestment) {
+      final categoryId = catByName[categoryName];
+      if (categoryId == null) continue;
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName ($accountType)',
@@ -141,5 +167,57 @@ class RuleSeeder {
     if (rules.isEmpty) return false;
     await _autoCatRepo.insertRules(rules);
     return true;
+  }
+
+  /// Auto-maintenance rules originally pointed at the Transportation parent
+  /// category because the 'Auto Maintenance' subcategory didn't exist in the
+  /// seed yet. Now that it does, retarget any seeded rule that the user
+  /// hasn't touched (createdAt == updatedAt) to the new subcategory.
+  ///
+  /// Returns true if any rules were retargeted. Skipped if 'Auto Maintenance'
+  /// hasn't been seeded yet (CategorySeeder backfill should run first).
+  Future<bool> _retargetAutoMaintenanceRules() async {
+    const autoMaintenancePayees = {
+      'JIFFY LUBE', 'VALVOLINE', 'FIRESTONE', 'AUTOZONE', 'PEP BOYS',
+      "O'REILLY", 'ADVANCE AUTO', 'NAPA AUTO', 'MIDAS', 'GOODYEAR',
+      'DISCOUNT TIRE', 'MAACO', 'MEINEKE', 'SAFELITE',
+    };
+
+    final categories = await _categoryRepo.getAllCategories();
+    String? transportationParentId;
+    String? autoMaintenanceId;
+    for (final c in categories) {
+      if (c.parentId == null && c.name == 'Transportation') {
+        transportationParentId = c.id;
+      } else if (c.parentId != null && c.name == 'Auto Maintenance') {
+        autoMaintenanceId = c.id;
+      }
+    }
+    if (transportationParentId == null || autoMaintenanceId == null) {
+      return false;
+    }
+
+    final rules = await _autoCatRepo.getEnabledRules();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    var retargetCount = 0;
+    for (final r in rules) {
+      if (r.payeeContains == null) continue;
+      if (!autoMaintenancePayees.contains(r.payeeContains!.toUpperCase())) {
+        continue;
+      }
+      if (r.categoryId != transportationParentId) continue;
+      if (r.updatedAt != r.createdAt) continue; // user-edited; leave alone
+
+      await _autoCatRepo.updateRule(
+        AutoCategorizeRulesCompanion(
+          id: Value(r.id),
+          categoryId: Value(autoMaintenanceId),
+          updatedAt: Value(now),
+        ),
+      );
+      retargetCount++;
+    }
+
+    return retargetCount > 0;
   }
 }

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -40,18 +40,27 @@ class _AutoCategorizeRulesScreenState
       duration: Duration(seconds: 2),
     ));
     try {
+      // Snapshot the uncategorized total before running so we can
+      // differentiate "nothing to do" from "ran but nothing matched".
+      final pendingBefore = await ref
+          .read(transactionRepositoryProvider)
+          .getUncategorizedTransactions();
       final count =
           await ref.read(autoCategorizeServiceProvider).categorizeUncategorized();
       if (!mounted) return;
       invalidateFinancialData(ref);
       messenger.hideCurrentSnackBar();
-      messenger.showSnackBar(SnackBar(
-        content: Text(
-          count == 0
-              ? 'No uncategorized transactions matched any rule'
-              : 'Categorized $count transaction${count == 1 ? '' : 's'}',
-        ),
-      ));
+      final String message;
+      if (pendingBefore.isEmpty) {
+        message = 'Nothing to categorize — no uncategorized transactions';
+      } else if (count == 0) {
+        message = '${pendingBefore.length} uncategorized transaction'
+            '${pendingBefore.length == 1 ? '' : 's'} '
+            'didn\'t match any rule';
+      } else {
+        message = 'Categorized $count transaction${count == 1 ? '' : 's'}';
+      }
+      messenger.showSnackBar(SnackBar(content: Text(message)));
     } catch (e) {
       if (!mounted) return;
       messenger.hideCurrentSnackBar();

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -5,6 +5,8 @@ import 'package:uuid/uuid.dart';
 
 import '../../../core/di/providers.dart';
 import '../../../data/local/database/models.dart';
+import '../../../domain/usecases/categorize/rule_conflicts.dart';
+import '../../shared/utils/provider_invalidation.dart';
 import '../../shared/widgets/category_picker_sheet.dart';
 import 'auto_categorize_providers.dart';
 
@@ -21,11 +23,45 @@ class _AutoCategorizeRulesScreenState
     extends ConsumerState<AutoCategorizeRulesScreen> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
+  bool _isRunning = false;
 
   @override
   void dispose() {
     _searchController.dispose();
     super.dispose();
+  }
+
+  Future<void> _runRecategorize() async {
+    if (_isRunning) return;
+    setState(() => _isRunning = true);
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(const SnackBar(
+      content: Text('Categorizing uncategorized transactions…'),
+      duration: Duration(seconds: 2),
+    ));
+    try {
+      final count =
+          await ref.read(autoCategorizeServiceProvider).categorizeUncategorized();
+      if (!mounted) return;
+      invalidateFinancialData(ref);
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(
+        content: Text(
+          count == 0
+              ? 'No uncategorized transactions matched any rule'
+              : 'Categorized $count transaction${count == 1 ? '' : 's'}',
+        ),
+      ));
+    } catch (e) {
+      if (!mounted) return;
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(
+        content: Text('Re-categorize failed: $e'),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ));
+    } finally {
+      if (mounted) setState(() => _isRunning = false);
+    }
   }
 
   @override
@@ -45,6 +81,17 @@ class _AutoCategorizeRulesScreenState
       appBar: AppBar(
         title: const Text('Auto-Categorization Rules'),
         actions: [
+          IconButton(
+            icon: _isRunning
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.play_arrow),
+            tooltip: 'Re-categorize uncategorized transactions',
+            onPressed: _isRunning ? null : _runRecategorize,
+          ),
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: 'Add rule',
@@ -286,6 +333,21 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     super.dispose();
   }
 
+  List<RuleConflict> _computeConflicts(List<AutoCategorizeRule> existing) {
+    final priority =
+        int.tryParse(_priorityController.text.trim()) ?? 100;
+    return detectRuleConflicts(
+      editingRuleId: widget.rule?.id,
+      payeeContains: _payeeContainsController.text.trim().isEmpty
+          ? null
+          : _payeeContainsController.text.trim(),
+      payeeExact: widget.rule?.payeeExact,
+      categoryId: _selectedCategoryId,
+      priority: priority,
+      existingRules: existing,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // Resolve category name
@@ -296,11 +358,16 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
       });
     }
 
+    final existingRules =
+        ref.watch(autoCategorizeRulesProvider).valueOrNull ?? const [];
+    final conflicts = _computeConflicts(existingRules);
+
     return AlertDialog(
       title: Text(widget.rule == null ? 'Add Rule' : 'Edit Rule'),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             TextField(
               controller: _nameController,
@@ -313,6 +380,7 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
                 labelText: 'Payee Contains',
                 hintText: 'e.g. AMAZON',
               ),
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 12),
             TextField(
@@ -321,6 +389,7 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
                 labelText: 'Priority (lower = higher)',
               ),
               keyboardType: TextInputType.number,
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 12),
             ListTile(
@@ -330,6 +399,13 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
               trailing: const Icon(Icons.chevron_right),
               onTap: () => _pickCategory(context),
             ),
+            if (conflicts.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _ConflictWarning(
+                conflicts: conflicts,
+                priority: int.tryParse(_priorityController.text.trim()) ?? 100,
+              ),
+            ],
           ],
         ),
       ),
@@ -399,5 +475,70 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     }
 
     Navigator.pop(context);
+  }
+}
+
+class _ConflictWarning extends StatelessWidget {
+  const _ConflictWarning({required this.conflicts, required this.priority});
+
+  final List<RuleConflict> conflicts;
+  final int priority;
+
+  String _message(RuleConflict c) {
+    final otherName = c.other.name;
+    switch (c.kind) {
+      case RuleConflictKind.samePatternDifferentCategory:
+        return 'Rule "$otherName" uses the same pattern but maps to a '
+            'different category. Whichever has lower priority wins.';
+      case RuleConflictKind.shadowsOther:
+        return 'Rule "$otherName" is more specific; with this priority it '
+            'would never run.';
+      case RuleConflictKind.shadowedByOther:
+        return 'Rule "$otherName" is more general and runs first; lower '
+            'this rule\'s priority below ${c.other.priority}.';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.amber.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.amber.shade700),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning_amber, color: Colors.amber.shade800, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                conflicts.length == 1
+                    ? 'Possible conflict'
+                    : 'Possible conflicts (${conflicts.length})',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: scheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...conflicts.map(
+            (c) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text(
+                '• ${_message(c)}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:moneymoney/core/constants/app_constants.dart';
 import 'package:moneymoney/data/local/database/app_database.dart';
 import 'package:moneymoney/data/repositories/account_repository.dart';
 import 'package:moneymoney/data/repositories/auto_categorize_repository.dart';
 import 'package:moneymoney/data/repositories/transaction_repository.dart';
 import 'package:moneymoney/domain/usecases/categorize/auto_categorize_service.dart';
+import 'package:moneymoney/domain/usecases/categorize/default_rules_data.dart';
 
 class MockAutoCategorizeRepository extends Mock
     implements AutoCategorizeRepository {}
@@ -374,13 +376,16 @@ void main() {
       expect(captured.confidence.value, equals(0.7)); // 0.5 + 2*0.1
     });
 
-    test('resets on category change', () async {
+    test(
+        'mismatch on useCount=1 entry adopts new category at baseline (flip)',
+        () async {
+      // useCount=1 means no learning to protect; new category wins.
       when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
-          confidence: 0.9,
-          useCount: 4,
+          confidence: 0.6,
+          useCount: 1,
         ),
       );
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
@@ -398,6 +403,69 @@ void main() {
       expect(captured.categoryId.value, equals('cat-groceries'));
       expect(captured.useCount.value, equals(1));
       expect(captured.confidence.value, equals(0.5));
+    });
+
+    test(
+        'mismatch on useCount=3 entry keeps old category, demoted to useCount=2',
+        () async {
+      // useCount=3 is the minimum threshold (confidence=0.8). A single
+      // misclick demotes it to useCount=2/confidence=0.7 — falls below
+      // threshold so the user is prompted next time, but learning is
+      // preserved.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.8,
+          useCount: 3,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      // Old category preserved (dominance-keep)
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(2));
+      expect(captured.confidence.value, closeTo(0.7, 1e-9));
+    });
+
+    test(
+        'mismatch on useCount=8 entry keeps old category, confidence clamps to 1.0',
+        () async {
+      // High-confidence stability: a strong learning signal isn't wiped by
+      // one misclick.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 1.0,
+          useCount: 8,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(7));
+      expect(captured.confidence.value, equals(1.0));
     });
 
     test('logs correction when oldCategoryId differs', () async {
@@ -789,6 +857,67 @@ void main() {
 
       expect(count, equals(0));
       verifyNever(() => mockTxnRepo.updateCategory(any(), any()));
+    });
+  });
+
+  group('default rules data integrity', () {
+    test('no entry uses the bare LOVE substring (false-positive risk)', () {
+      // 'LOVE' as a payeeContains would match any payee with the
+      // substring (e.g. "I LOVE PIZZA"). The actual gas chain is
+      // 'Love's Travel Stops & Country Stores', which appears on
+      // statements as 'LOVES TRAVEL' or "LOVE'S TRAVEL".
+      final bare = defaultMerchantMappings.where((m) => m.$1 == 'LOVE');
+      expect(bare, isEmpty);
+    });
+
+    test('LOVES TRAVEL variants map to Gas', () {
+      final variants = defaultMerchantMappings
+          .where((m) => m.$1.contains('LOVE') && m.$2 == 'Gas')
+          .map((m) => m.$1)
+          .toSet();
+      expect(variants, contains('LOVES TRAVEL'));
+      expect(variants, contains("LOVE'S TRAVEL"));
+    });
+
+    test('Auto Maintenance is a seeded subcategory of Transportation', () {
+      final transport = DefaultCategories.expense
+          .firstWhere((c) => c['name'] == 'Transportation');
+      final children =
+          (transport['children'] as List).cast<String>();
+      expect(children, contains('Auto Maintenance'));
+    });
+
+    test('auto-maintenance merchants map to Auto Maintenance subcategory', () {
+      const autoMerchants = {
+        'JIFFY LUBE', 'VALVOLINE', 'FIRESTONE', 'AUTOZONE', 'PEP BOYS',
+        "O'REILLY", 'ADVANCE AUTO', 'NAPA AUTO', 'MIDAS', 'GOODYEAR',
+        'DISCOUNT TIRE', 'MAACO', 'MEINEKE', 'SAFELITE',
+      };
+      for (final m in autoMerchants) {
+        final rule = defaultMerchantMappings
+            .firstWhere((r) => r.$1 == m, orElse: () => ('', ''));
+        expect(rule.$1, isNotEmpty,
+            reason: '$m should be present in defaultMerchantMappings');
+        expect(rule.$2, equals('Auto Maintenance'),
+            reason: '$m should map to Auto Maintenance, got "${rule.$2}"');
+      }
+    });
+
+    test('every default rule targets a category that exists in seed data', () {
+      final allCategoryNames = <String>{
+        for (final c in DefaultCategories.expense) ...[
+          c['name'] as String,
+          ...((c['children'] as List?) ?? const []).cast<String>(),
+        ],
+        for (final c in DefaultCategories.income) ...[
+          c['name'] as String,
+          ...((c['children'] as List?) ?? const []).cast<String>(),
+        ],
+      };
+      for (final (payee, cat) in defaultMerchantMappings) {
+        expect(allCategoryNames.contains(cat), isTrue,
+            reason: 'Rule "$payee" targets unknown category "$cat"');
+      }
     });
   });
 }

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -406,6 +406,76 @@ void main() {
     });
 
     test(
+        'mismatch on useCount=2 entry keeps old category (boundary at >= 1)',
+        () async {
+      // Boundary case: useCount=2 means penalized=1, which is exactly the
+      // >= 1 threshold. A regression that flips the check to > 1 would
+      // silently flip useCount=2 entries instead of keeping them.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.7,
+          useCount: 2,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(1));
+      expect(captured.confidence.value, closeTo(0.6, 1e-9));
+    });
+
+    test(
+        'correction is logged even when cache keeps old category on mismatch',
+        () async {
+      // When dominance-keep preserves the old categoryId, the correction
+      // log must still record the user's actual choice for audit purposes.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.8,
+          useCount: 3,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+      when(() => mockAutoCatRepo.insertCorrection(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+        transactionId: 'txn-1',
+        oldCategoryId: 'cat-dining',
+      );
+
+      // Cache kept old category.
+      final cacheCaptured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(cacheCaptured.categoryId.value, equals('cat-dining'));
+
+      // But the correction was still logged with the user's intent.
+      final corrCaptured = verify(
+        () => mockAutoCatRepo.insertCorrection(captureAny()),
+      ).captured.single as CategorizationCorrectionsCompanion;
+      expect(corrCaptured.oldCategoryId.value, equals('cat-dining'));
+      expect(corrCaptured.newCategoryId.value, equals('cat-groceries'));
+    });
+
+    test(
         'mismatch on useCount=3 entry keeps old category, demoted to useCount=2',
         () async {
       // useCount=3 is the minimum threshold (confidence=0.8). A single

--- a/test/unit/usecases/categorize/rule_conflicts_test.dart
+++ b/test/unit/usecases/categorize/rule_conflicts_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moneymoney/data/local/database/app_database.dart';
+import 'package:moneymoney/domain/usecases/categorize/rule_conflicts.dart';
+
+AutoCategorizeRule _rule({
+  required String id,
+  String? payeeContains,
+  String? payeeExact,
+  required String categoryId,
+  required int priority,
+}) {
+  return AutoCategorizeRule(
+    id: id,
+    name: 'rule-$id',
+    priority: priority,
+    payeeContains: payeeContains,
+    payeeExact: payeeExact,
+    amountMinCents: null,
+    amountMaxCents: null,
+    accountId: null,
+    categoryId: categoryId,
+    accountType: null,
+    isEnabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+  );
+}
+
+void main() {
+  group('detectRuleConflicts', () {
+    test('returns empty when no existing rules', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: const [],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('returns empty when proposed rule has no payee pattern', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: null,
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-other',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('same payeeContains pattern with same category — no conflict', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-shopping',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('same payeeContains pattern with different category — warns', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'amazon', // case-insensitive
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind,
+          equals(RuleConflictKind.samePatternDifferentCategory));
+    });
+
+    test('this rule shadows a more-specific existing rule with same priority',
+        () {
+      // New rule contains "AMAZON" priority 10. Existing "AMAZON FRESH" priority 50.
+      // New rule's match set strictly contains existing's, and new has lower
+      // priority number → it fires first → existing never runs.
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON FRESH',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
+    });
+
+    test('this rule is shadowed by a more-general existing rule', () {
+      // New rule contains "AMAZON FRESH" priority 50. Existing "AMAZON" priority 10.
+      // Existing matches everything new does (and more), and existing fires
+      // first → new never runs.
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON FRESH',
+        payeeExact: null,
+        categoryId: 'cat-groceries',
+        priority: 50,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-shopping',
+            priority: 10,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowedByOther));
+    });
+
+    test('edit-self does not conflict with self', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: 'q',
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('cross-field: new payeeContains "AMAZON" shadows existing exact "AMAZON FRESH"',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeExact: 'AMAZON FRESH',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
+    });
+
+    test('rules without payee patterns are skipped (amount/accountType only)',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q-no-payee',
+            payeeContains: null,
+            payeeExact: null,
+            categoryId: 'cat-other',
+            priority: 5,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+  });
+}

--- a/test/unit/usecases/categorize/rule_conflicts_test.dart
+++ b/test/unit/usecases/categorize/rule_conflicts_test.dart
@@ -186,6 +186,26 @@ void main() {
       expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
     });
 
+    test('whitespace-only payeeContains is treated as empty (no false matches)',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: '   ',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-other',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
     test('rules without payee patterns are skipped (amount/accountType only)',
         () {
       final conflicts = detectRuleConflicts(

--- a/test/unit/usecases/categorize/rule_seeder_test.dart
+++ b/test/unit/usecases/categorize/rule_seeder_test.dart
@@ -1,0 +1,359 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moneymoney/data/local/database/app_database.dart';
+import 'package:moneymoney/data/repositories/auto_categorize_repository.dart';
+import 'package:moneymoney/data/repositories/category_repository.dart';
+import 'package:moneymoney/domain/usecases/categorize/rule_seeder.dart';
+
+class MockAutoCategorizeRepository extends Mock
+    implements AutoCategorizeRepository {}
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late MockAutoCategorizeRepository autoCatRepo;
+  late MockCategoryRepository categoryRepo;
+  late RuleSeeder seeder;
+
+  setUp(() {
+    autoCatRepo = MockAutoCategorizeRepository();
+    categoryRepo = MockCategoryRepository();
+    seeder = RuleSeeder(categoryRepo, autoCatRepo);
+  });
+
+  setUpAll(() {
+    registerFallbackValue(const AutoCategorizeRulesCompanion());
+  });
+
+  Category cat({
+    required String id,
+    required String name,
+    String? parentId,
+  }) {
+    return Category(
+      id: id,
+      name: name,
+      parentId: parentId,
+      type: 'expense',
+      icon: 'category',
+      color: 0xFF000000,
+      displayOrder: 0,
+      isSystem: false,
+      createdAt: 0,
+      updatedAt: 0,
+      version: 1,
+      syncStatus: 0,
+    );
+  }
+
+  AutoCategorizeRule rule({
+    required String id,
+    required String payeeContains,
+    required String categoryId,
+    required int createdAt,
+    required int updatedAt,
+    int priority = 0,
+  }) {
+    return AutoCategorizeRule(
+      id: id,
+      name: '$payeeContains → cat',
+      priority: priority,
+      payeeContains: payeeContains,
+      payeeExact: null,
+      amountMinCents: null,
+      amountMaxCents: null,
+      accountId: null,
+      categoryId: categoryId,
+      accountType: null,
+      isEnabled: true,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  group('_retargetAutoMaintenanceRules (via seedIfEmpty)', () {
+    test('retargets seeded JIFFY LUBE rule to Auto Maintenance', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      final captured = verify(() => autoCatRepo.updateRule(captureAny()))
+          .captured
+          .cast<AutoCategorizeRulesCompanion>();
+      expect(captured.length, equals(1));
+      expect(captured.first.id.value, equals('rule-jiffy'));
+      expect(captured.first.categoryId.value, equals('automaint'));
+    });
+
+    test('skips rules with updatedAt != createdAt (user-edited)', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-edited',
+              payeeContains: 'AUTOZONE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 2000, // user edited
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips rules already pointing at a different category', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+            cat(id: 'misc', name: 'Miscellaneous'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-already-moved',
+              payeeContains: 'SAFELITE',
+              categoryId: 'misc', // not the Transportation parent
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips non-auto-maintenance merchants', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-shell',
+              payeeContains: 'SHELL', // gas, not maintenance
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('no-op when Auto Maintenance subcategory does not exist', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            // no Auto Maintenance child
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips rules with null payeeContains', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'rule-noPattern',
+              name: 'amount-only rule',
+              priority: 0,
+              payeeContains: null,
+              payeeExact: null,
+              amountMinCents: 100,
+              amountMaxCents: 1000,
+              accountId: null,
+              categoryId: 'trans',
+              accountType: null,
+              isEnabled: true,
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('retargets multiple rules and reports backfill via return value',
+        () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+            rule(
+              id: 'rule-autozone',
+              payeeContains: 'AUTOZONE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+            rule(
+              id: 'rule-oreilly',
+              payeeContains: "O'REILLY",
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      verify(() => autoCatRepo.updateRule(any())).called(3);
+    });
+  });
+
+  group('_backfillMissingDefaultRules (via seedIfEmpty)', () {
+    test('inserts a missing general rule for an existing user', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // Existing user only has KROGER; missing TESLA SUPERCHARGER and others.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'existing',
+              payeeContains: 'KROGER',
+              categoryId: 'gas',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      final captured = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Should contain TESLA SUPERCHARGER → Gas (new 2025-era rule).
+      final hasTesla = captured.any((c) =>
+          c.payeeContains.value == 'TESLA SUPERCHARGER' &&
+          c.categoryId.value == 'gas');
+      expect(hasTesla, isTrue);
+      // Should NOT re-insert KROGER (already exists).
+      final hasKroger =
+          captured.any((c) => c.payeeContains.value == 'KROGER');
+      expect(hasKroger, isFalse);
+    });
+
+    test('skips general rules whose payeeContains already exists', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // User has all the EV charging rules already.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'user-tesla',
+              payeeContains: 'TESLA SUPERCHARGER',
+              categoryId: 'gas',
+              createdAt: 1000,
+              updatedAt: 2000, // user-edited; dedup still applies
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      // Anything inserted should not include TESLA SUPERCHARGER.
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      final hasTeslaSupercharger = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaSupercharger, isFalse);
+    });
+
+    test('inserts investment rule with same payeeContains as general rule',
+        () async {
+      // An investment rule with the same payeeContains but a different
+      // accountType has a distinct dedup key, so should be inserted.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'interest', name: 'Interest'),
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // User has a general 'INTEREST' rule but no investment-scoped one.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'general',
+              payeeContains: 'INTEREST',
+              categoryId: 'interest',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Investment 'INTEREST' rule for brokerage should still be inserted.
+      final hasInvestmentInterest = inserted.any((c) =>
+          c.payeeContains.value == 'INTEREST' &&
+          c.accountType.value == 'brokerage');
+      expect(hasInvestmentInterest, isTrue);
+    });
+  });
+}

--- a/test/unit/usecases/categorize/rule_seeder_test.dart
+++ b/test/unit/usecases/categorize/rule_seeder_test.dart
@@ -78,7 +78,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -88,17 +88,17 @@ void main() {
             ),
           ]);
       when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
-      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRulesCategoryBatch(any(), any())).thenAnswer((_) async {});
 
       final result = await seeder.seedIfEmpty();
 
       expect(result, isTrue);
-      final captured = verify(() => autoCatRepo.updateRule(captureAny()))
+      final captured = verify(() =>
+              autoCatRepo.updateRulesCategoryBatch(captureAny(), any()))
           .captured
-          .cast<AutoCategorizeRulesCompanion>();
+          .single as Map<String, String>;
       expect(captured.length, equals(1));
-      expect(captured.first.id.value, equals('rule-jiffy'));
-      expect(captured.first.categoryId.value, equals('automaint'));
+      expect(captured['rule-jiffy'], equals('automaint'));
     });
 
     test('skips rules with updatedAt != createdAt (user-edited)', () async {
@@ -107,7 +107,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-edited',
               payeeContains: 'AUTOZONE',
@@ -120,7 +120,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips rules already pointing at a different category', () async {
@@ -130,7 +130,7 @@ void main() {
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
             cat(id: 'misc', name: 'Miscellaneous'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-already-moved',
               payeeContains: 'SAFELITE',
@@ -143,7 +143,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips non-auto-maintenance merchants', () async {
@@ -152,7 +152,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-shell',
               payeeContains: 'SHELL', // gas, not maintenance
@@ -165,7 +165,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('no-op when Auto Maintenance subcategory does not exist', () async {
@@ -174,7 +174,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             // no Auto Maintenance child
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -187,7 +187,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips rules with null payeeContains', () async {
@@ -196,7 +196,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             const AutoCategorizeRule(
               id: 'rule-noPattern',
               name: 'amount-only rule',
@@ -217,7 +217,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('retargets multiple rules and reports backfill via return value',
@@ -227,7 +227,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -251,12 +251,19 @@ void main() {
             ),
           ]);
       when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
-      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRulesCategoryBatch(any(), any())).thenAnswer((_) async {});
 
       final result = await seeder.seedIfEmpty();
 
       expect(result, isTrue);
-      verify(() => autoCatRepo.updateRule(any())).called(3);
+      // Batched: one call with all three retargets in the map.
+      final captured = verify(() =>
+              autoCatRepo.updateRulesCategoryBatch(captureAny(), any()))
+          .captured
+          .single as Map<String, String>;
+      expect(captured.length, equals(3));
+      expect(captured.keys, containsAll(['rule-jiffy', 'rule-autozone', 'rule-oreilly']));
+      expect(captured.values, everyElement(equals('automaint')));
     });
   });
 
@@ -267,7 +274,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // Existing user only has KROGER; missing TESLA SUPERCHARGER and others.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'existing',
               payeeContains: 'KROGER',
@@ -301,7 +308,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // User has all the EV charging rules already.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'user-tesla',
               payeeContains: 'TESLA SUPERCHARGER',
@@ -323,6 +330,85 @@ void main() {
       expect(hasTeslaSupercharger, isFalse);
     });
 
+    test('does NOT duplicate a default rule that the user has disabled',
+        () async {
+      // Regression test for the bug where dedup used getEnabledRules,
+      // missing user-disabled rules and re-inserting duplicates on every
+      // upgrade.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'disabled-tesla',
+              name: 'TESLA SUPERCHARGER → Gas',
+              priority: 100,
+              payeeContains: 'TESLA SUPERCHARGER',
+              payeeExact: null,
+              amountMinCents: null,
+              amountMaxCents: null,
+              accountId: null,
+              categoryId: 'gas',
+              accountType: null,
+              isEnabled: false, // user disabled
+              createdAt: 1000,
+              updatedAt: 2000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Critical: should NOT re-insert TESLA SUPERCHARGER even though
+      // the existing rule is disabled.
+      final hasTeslaDuplicate = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaDuplicate, isFalse,
+          reason: 'disabled rule should still dedupe');
+    });
+
+    test('does NOT duplicate a default rule the user has customized', () async {
+      // Companion to the disabled-rule test: an enabled rule with the same
+      // payeeContains but a user-customized name/category should also dedupe.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+            cat(id: 'misc', name: 'Miscellaneous'),
+          ]);
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'custom-tesla',
+              name: 'My custom Tesla rule',
+              priority: 5,
+              payeeContains: 'TESLA SUPERCHARGER',
+              payeeExact: null,
+              amountMinCents: null,
+              amountMaxCents: null,
+              accountId: null,
+              categoryId: 'misc', // user mapped it elsewhere
+              accountType: null,
+              isEnabled: true,
+              createdAt: 1000,
+              updatedAt: 2000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      final hasTeslaDuplicate = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaDuplicate, isFalse,
+          reason: 'user-customized rule should dedupe; their choice wins');
+    });
+
     test('inserts investment rule with same payeeContains as general rule',
         () async {
       // An investment rule with the same payeeContains but a different
@@ -333,7 +419,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // User has a general 'INTEREST' rule but no investment-scoped one.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'general',
               payeeContains: 'INTEREST',


### PR DESCRIPTION
## Summary

Phase 1 of auto-categorization improvements per `~/.claude/plans/plan-out-ways-to-jolly-clover.md`. Six surgical changes, no schema migration, all 314 tests pass.

## Changes

- **1.1** Fix `LOVE → Gas` false positive in default rules. Replaced bare `'LOVE'` with `'LOVES TRAVEL'` and `"LOVE'S TRAVEL"` (apostrophe survives normalization).
- **1.2** Add `Auto Maintenance` subcategory under Transportation. Retarget the 14 auto-maintenance rules (JIFFY LUBE, AUTOZONE, etc.) from the Transportation parent to the new subcategory. One-shot retarget backfill in `RuleSeeder`, guarded by `updatedAt == createdAt` so user-edited rules are left alone.
- **1.3** Append ~45 curated 2025-era merchant rules: EV charging, telehealth, modern subscriptions (ChatGPT, Anthropic, Substack, Patreon), micromobility (Lime, Bird Rides), Costco warehouse strings, Sweetgreen, Cava, etc. Excluded crypto/P2P/tolls (no category fit) and collision-prone bare substrings (TARGET, COSTCO, BIRD, REI, MAX). `_backfillInvestmentRules` extended into a general `_backfillMissingDefaultRules` so existing users get new merchant rules automatically; user-defined rules with identical `payeeContains` are respected.
- **1.4** Add "Re-categorize Uncategorized" play-arrow action in the rules screen AppBar. Calls existing `categorizeUncategorized()`, snackbars + dashboard invalidation, guarded against re-entry.
- **1.5** Inline rule-conflict warning in the rule create/edit dialog. Three checks (same-pattern-different-cat, this-rule-shadows-other, this-rule-shadowed-by-other) with cross-field `payeeExact`/`payeeContains` handling. Save never blocked. Predicate extracted to `rule_conflicts.dart` for unit testing.
- **1.6** Soften confidence reset (dominance-keep). A category mismatch no longer wipes learned state — `useCount` is decremented by 1 and the existing category is preserved unless its weight reaches zero. Protects the minimum-threshold (useCount=3) entry from a single misclick.

## Notable trade-offs

- **No auto-cleanup of existing bad `LOVE → Gas` rule** in user DBs (risk of overwriting user edits). Users can disable it manually; documented in CHANGELOG.
- **New `Auto Maintenance` subcategory is backfilled** for existing users via `CategorySeeder._backfillMissing`; the 14 auto-maintenance rule retargets are also backfilled (guarded by `updatedAt == createdAt`).
- **Conflict warnings are warnings, not blockers** — save still works. Documented limitation: rules with only `amountRange`/`accountType` filters (no payee pattern) aren't checked.

## Test plan

- [x] `flutter analyze` clean on all touched files
- [x] `flutter test` passes (314/314)
- [ ] Fresh-install smoke: verify Auto Maintenance subcategory appears under Transportation; `JIFFY LUBE` → Auto Maintenance; `TESLA SUPERCHARGER` → Gas; `I LOVE PIZZA` does NOT match Gas; `LOVES TRAVEL STOP 392` → Gas
- [ ] Upgraded-install smoke: verify Auto Maintenance subcategory + retarget backfill runs on next launch; user-edited rules untouched
- [ ] Settings → tap play icon → snackbar shows count; dashboard aggregates refresh
- [ ] Create a rule with `payeeContains: 'AMAZON'` priority 10 while `'AMAZON FRESH'` exists at priority 50 → inline warning appears; save still works
- [ ] Cache-stability: categorize STARBUCKS as Coffee 5 times, misclick once to Groceries → next STARBUCKS still auto-categorizes to Coffee

🤖 Generated with [Claude Code](https://claude.com/claude-code)