### PR TITLE
feat(categorize): phase 2 — account-aware cache + 3rd-correction rule prompt

### DIFF
--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -214,8 +214,15 @@ class RecurringTransactions extends Table {
 // =============================================================================
 
 /// Tier 1: payee → category lookup cache.
+///
+/// `accountBucket` partitions the cache into 'standard' (checking, savings,
+/// credit cards) vs 'investment' (brokerage, 401k, IRA, HSA, crypto). The
+/// same payee can have different semantics across the two — e.g. STARBUCKS
+/// is Coffee Shops in checking but Investment Fees in a brokerage account.
 class PayeeCategoryCache extends Table {
   TextColumn get payeeNormalized => text()();
+  TextColumn get accountBucket =>
+      text().withDefault(const Constant('standard'))();
   TextColumn get categoryId => text()();
   RealColumn get confidence => real()();
   TextColumn get source => text()();
@@ -223,7 +230,7 @@ class PayeeCategoryCache extends Table {
   IntColumn get updatedAt => integer()();
 
   @override
-  Set<Column> get primaryKey => {payeeNormalized};
+  Set<Column> get primaryKey => {payeeNormalized, accountBucket};
 }
 
 /// User correction history for categorization learning.
@@ -410,7 +417,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -518,6 +525,38 @@ class AppDatabase extends _$AppDatabase {
           if (from < 6) {
             await customStatement(
               'ALTER TABLE auto_categorize_rules ADD COLUMN account_type TEXT',
+            );
+          }
+
+          // v6 → v7: Add accountBucket to PayeeCategoryCache with composite PK
+          // (payee_normalized, account_bucket). SQLite cannot redefine a
+          // primary key in place — use the table-rebuild pattern. Existing
+          // rows default to 'standard' (non-investment) which matches the
+          // historic single-bucket behavior.
+          if (from < 7) {
+            await customStatement('''
+              CREATE TABLE payee_category_cache_new (
+                payee_normalized TEXT NOT NULL,
+                account_bucket TEXT NOT NULL DEFAULT 'standard',
+                category_id TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                source TEXT NOT NULL,
+                use_count INTEGER NOT NULL DEFAULT 1,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (payee_normalized, account_bucket)
+              )
+            ''');
+            await customStatement('''
+              INSERT INTO payee_category_cache_new
+                (payee_normalized, account_bucket, category_id, confidence,
+                 source, use_count, updated_at)
+              SELECT payee_normalized, 'standard', category_id, confidence,
+                     source, use_count, updated_at
+              FROM payee_category_cache
+            ''');
+            await customStatement('DROP TABLE payee_category_cache');
+            await customStatement(
+              'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
             );
           }
         },

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -533,31 +533,37 @@ class AppDatabase extends _$AppDatabase {
           // primary key in place — use the table-rebuild pattern. Existing
           // rows default to 'standard' (non-investment) which matches the
           // historic single-bucket behavior.
+          //
+          // Drift wraps onUpgrade in a transaction by default; the explicit
+          // transaction() here makes the atomicity intent legible to anyone
+          // scanning the migration and protects against future Drift changes.
           if (from < 7) {
-            await customStatement('''
-              CREATE TABLE payee_category_cache_new (
-                payee_normalized TEXT NOT NULL,
-                account_bucket TEXT NOT NULL DEFAULT 'standard',
-                category_id TEXT NOT NULL,
-                confidence REAL NOT NULL,
-                source TEXT NOT NULL,
-                use_count INTEGER NOT NULL DEFAULT 1,
-                updated_at INTEGER NOT NULL,
-                PRIMARY KEY (payee_normalized, account_bucket)
-              )
-            ''');
-            await customStatement('''
-              INSERT INTO payee_category_cache_new
-                (payee_normalized, account_bucket, category_id, confidence,
-                 source, use_count, updated_at)
-              SELECT payee_normalized, 'standard', category_id, confidence,
-                     source, use_count, updated_at
-              FROM payee_category_cache
-            ''');
-            await customStatement('DROP TABLE payee_category_cache');
-            await customStatement(
-              'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
-            );
+            await transaction(() async {
+              await customStatement('''
+                CREATE TABLE payee_category_cache_new (
+                  payee_normalized TEXT NOT NULL,
+                  account_bucket TEXT NOT NULL DEFAULT 'standard',
+                  category_id TEXT NOT NULL,
+                  confidence REAL NOT NULL,
+                  source TEXT NOT NULL,
+                  use_count INTEGER NOT NULL DEFAULT 1,
+                  updated_at INTEGER NOT NULL,
+                  PRIMARY KEY (payee_normalized, account_bucket)
+                )
+              ''');
+              await customStatement('''
+                INSERT INTO payee_category_cache_new
+                  (payee_normalized, account_bucket, category_id, confidence,
+                   source, use_count, updated_at)
+                SELECT payee_normalized, 'standard', category_id, confidence,
+                       source, use_count, updated_at
+                FROM payee_category_cache
+              ''');
+              await customStatement('DROP TABLE payee_category_cache');
+              await customStatement(
+                'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
+              );
+            });
           }
         },
         beforeOpen: (details) async {

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -7844,6 +7844,18 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _accountBucketMeta = const VerificationMeta(
+    'accountBucket',
+  );
+  @override
+  late final GeneratedColumn<String> accountBucket = GeneratedColumn<String>(
+    'account_bucket',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('standard'),
+  );
   static const VerificationMeta _categoryIdMeta = const VerificationMeta(
     'categoryId',
   );
@@ -7901,6 +7913,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
   @override
   List<GeneratedColumn> get $columns => [
     payeeNormalized,
+    accountBucket,
     categoryId,
     confidence,
     source,
@@ -7929,6 +7942,15 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
       );
     } else if (isInserting) {
       context.missing(_payeeNormalizedMeta);
+    }
+    if (data.containsKey('account_bucket')) {
+      context.handle(
+        _accountBucketMeta,
+        accountBucket.isAcceptableOrUnknown(
+          data['account_bucket']!,
+          _accountBucketMeta,
+        ),
+      );
     }
     if (data.containsKey('category_id')) {
       context.handle(
@@ -7972,7 +7994,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {payeeNormalized};
+  Set<GeneratedColumn> get $primaryKey => {payeeNormalized, accountBucket};
   @override
   PayeeCategoryCacheData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
@@ -7980,6 +8002,10 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
       payeeNormalized: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}payee_normalized'],
+      )!,
+      accountBucket: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}account_bucket'],
       )!,
       categoryId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -8013,6 +8039,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
 class PayeeCategoryCacheData extends DataClass
     implements Insertable<PayeeCategoryCacheData> {
   final String payeeNormalized;
+  final String accountBucket;
   final String categoryId;
   final double confidence;
   final String source;
@@ -8020,6 +8047,7 @@ class PayeeCategoryCacheData extends DataClass
   final int updatedAt;
   const PayeeCategoryCacheData({
     required this.payeeNormalized,
+    required this.accountBucket,
     required this.categoryId,
     required this.confidence,
     required this.source,
@@ -8030,6 +8058,7 @@ class PayeeCategoryCacheData extends DataClass
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['payee_normalized'] = Variable<String>(payeeNormalized);
+    map['account_bucket'] = Variable<String>(accountBucket);
     map['category_id'] = Variable<String>(categoryId);
     map['confidence'] = Variable<double>(confidence);
     map['source'] = Variable<String>(source);
@@ -8041,6 +8070,7 @@ class PayeeCategoryCacheData extends DataClass
   PayeeCategoryCacheCompanion toCompanion(bool nullToAbsent) {
     return PayeeCategoryCacheCompanion(
       payeeNormalized: Value(payeeNormalized),
+      accountBucket: Value(accountBucket),
       categoryId: Value(categoryId),
       confidence: Value(confidence),
       source: Value(source),
@@ -8056,6 +8086,7 @@ class PayeeCategoryCacheData extends DataClass
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return PayeeCategoryCacheData(
       payeeNormalized: serializer.fromJson<String>(json['payeeNormalized']),
+      accountBucket: serializer.fromJson<String>(json['accountBucket']),
       categoryId: serializer.fromJson<String>(json['categoryId']),
       confidence: serializer.fromJson<double>(json['confidence']),
       source: serializer.fromJson<String>(json['source']),
@@ -8068,6 +8099,7 @@ class PayeeCategoryCacheData extends DataClass
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'payeeNormalized': serializer.toJson<String>(payeeNormalized),
+      'accountBucket': serializer.toJson<String>(accountBucket),
       'categoryId': serializer.toJson<String>(categoryId),
       'confidence': serializer.toJson<double>(confidence),
       'source': serializer.toJson<String>(source),
@@ -8078,6 +8110,7 @@ class PayeeCategoryCacheData extends DataClass
 
   PayeeCategoryCacheData copyWith({
     String? payeeNormalized,
+    String? accountBucket,
     String? categoryId,
     double? confidence,
     String? source,
@@ -8085,6 +8118,7 @@ class PayeeCategoryCacheData extends DataClass
     int? updatedAt,
   }) => PayeeCategoryCacheData(
     payeeNormalized: payeeNormalized ?? this.payeeNormalized,
+    accountBucket: accountBucket ?? this.accountBucket,
     categoryId: categoryId ?? this.categoryId,
     confidence: confidence ?? this.confidence,
     source: source ?? this.source,
@@ -8096,6 +8130,9 @@ class PayeeCategoryCacheData extends DataClass
       payeeNormalized: data.payeeNormalized.present
           ? data.payeeNormalized.value
           : this.payeeNormalized,
+      accountBucket: data.accountBucket.present
+          ? data.accountBucket.value
+          : this.accountBucket,
       categoryId: data.categoryId.present
           ? data.categoryId.value
           : this.categoryId,
@@ -8112,6 +8149,7 @@ class PayeeCategoryCacheData extends DataClass
   String toString() {
     return (StringBuffer('PayeeCategoryCacheData(')
           ..write('payeeNormalized: $payeeNormalized, ')
+          ..write('accountBucket: $accountBucket, ')
           ..write('categoryId: $categoryId, ')
           ..write('confidence: $confidence, ')
           ..write('source: $source, ')
@@ -8124,6 +8162,7 @@ class PayeeCategoryCacheData extends DataClass
   @override
   int get hashCode => Object.hash(
     payeeNormalized,
+    accountBucket,
     categoryId,
     confidence,
     source,
@@ -8135,6 +8174,7 @@ class PayeeCategoryCacheData extends DataClass
       identical(this, other) ||
       (other is PayeeCategoryCacheData &&
           other.payeeNormalized == this.payeeNormalized &&
+          other.accountBucket == this.accountBucket &&
           other.categoryId == this.categoryId &&
           other.confidence == this.confidence &&
           other.source == this.source &&
@@ -8145,6 +8185,7 @@ class PayeeCategoryCacheData extends DataClass
 class PayeeCategoryCacheCompanion
     extends UpdateCompanion<PayeeCategoryCacheData> {
   final Value<String> payeeNormalized;
+  final Value<String> accountBucket;
   final Value<String> categoryId;
   final Value<double> confidence;
   final Value<String> source;
@@ -8153,6 +8194,7 @@ class PayeeCategoryCacheCompanion
   final Value<int> rowid;
   const PayeeCategoryCacheCompanion({
     this.payeeNormalized = const Value.absent(),
+    this.accountBucket = const Value.absent(),
     this.categoryId = const Value.absent(),
     this.confidence = const Value.absent(),
     this.source = const Value.absent(),
@@ -8162,6 +8204,7 @@ class PayeeCategoryCacheCompanion
   });
   PayeeCategoryCacheCompanion.insert({
     required String payeeNormalized,
+    this.accountBucket = const Value.absent(),
     required String categoryId,
     required double confidence,
     required String source,
@@ -8175,6 +8218,7 @@ class PayeeCategoryCacheCompanion
        updatedAt = Value(updatedAt);
   static Insertable<PayeeCategoryCacheData> custom({
     Expression<String>? payeeNormalized,
+    Expression<String>? accountBucket,
     Expression<String>? categoryId,
     Expression<double>? confidence,
     Expression<String>? source,
@@ -8184,6 +8228,7 @@ class PayeeCategoryCacheCompanion
   }) {
     return RawValuesInsertable({
       if (payeeNormalized != null) 'payee_normalized': payeeNormalized,
+      if (accountBucket != null) 'account_bucket': accountBucket,
       if (categoryId != null) 'category_id': categoryId,
       if (confidence != null) 'confidence': confidence,
       if (source != null) 'source': source,
@@ -8195,6 +8240,7 @@ class PayeeCategoryCacheCompanion
 
   PayeeCategoryCacheCompanion copyWith({
     Value<String>? payeeNormalized,
+    Value<String>? accountBucket,
     Value<String>? categoryId,
     Value<double>? confidence,
     Value<String>? source,
@@ -8204,6 +8250,7 @@ class PayeeCategoryCacheCompanion
   }) {
     return PayeeCategoryCacheCompanion(
       payeeNormalized: payeeNormalized ?? this.payeeNormalized,
+      accountBucket: accountBucket ?? this.accountBucket,
       categoryId: categoryId ?? this.categoryId,
       confidence: confidence ?? this.confidence,
       source: source ?? this.source,
@@ -8218,6 +8265,9 @@ class PayeeCategoryCacheCompanion
     final map = <String, Expression>{};
     if (payeeNormalized.present) {
       map['payee_normalized'] = Variable<String>(payeeNormalized.value);
+    }
+    if (accountBucket.present) {
+      map['account_bucket'] = Variable<String>(accountBucket.value);
     }
     if (categoryId.present) {
       map['category_id'] = Variable<String>(categoryId.value);
@@ -8244,6 +8294,7 @@ class PayeeCategoryCacheCompanion
   String toString() {
     return (StringBuffer('PayeeCategoryCacheCompanion(')
           ..write('payeeNormalized: $payeeNormalized, ')
+          ..write('accountBucket: $accountBucket, ')
           ..write('categoryId: $categoryId, ')
           ..write('confidence: $confidence, ')
           ..write('source: $source, ')
@@ -16630,6 +16681,7 @@ typedef $$RecurringTransactionsTableProcessedTableManager =
 typedef $$PayeeCategoryCacheTableCreateCompanionBuilder =
     PayeeCategoryCacheCompanion Function({
       required String payeeNormalized,
+      Value<String> accountBucket,
       required String categoryId,
       required double confidence,
       required String source,
@@ -16640,6 +16692,7 @@ typedef $$PayeeCategoryCacheTableCreateCompanionBuilder =
 typedef $$PayeeCategoryCacheTableUpdateCompanionBuilder =
     PayeeCategoryCacheCompanion Function({
       Value<String> payeeNormalized,
+      Value<String> accountBucket,
       Value<String> categoryId,
       Value<double> confidence,
       Value<String> source,
@@ -16659,6 +16712,11 @@ class $$PayeeCategoryCacheTableFilterComposer
   });
   ColumnFilters<String> get payeeNormalized => $composableBuilder(
     column: $table.payeeNormalized,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -16702,6 +16760,11 @@ class $$PayeeCategoryCacheTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get categoryId => $composableBuilder(
     column: $table.categoryId,
     builder: (column) => ColumnOrderings(column),
@@ -16739,6 +16802,11 @@ class $$PayeeCategoryCacheTableAnnotationComposer
   });
   GeneratedColumn<String> get payeeNormalized => $composableBuilder(
     column: $table.payeeNormalized,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
     builder: (column) => column,
   );
 
@@ -16803,6 +16871,7 @@ class $$PayeeCategoryCacheTableTableManager
           updateCompanionCallback:
               ({
                 Value<String> payeeNormalized = const Value.absent(),
+                Value<String> accountBucket = const Value.absent(),
                 Value<String> categoryId = const Value.absent(),
                 Value<double> confidence = const Value.absent(),
                 Value<String> source = const Value.absent(),
@@ -16811,6 +16880,7 @@ class $$PayeeCategoryCacheTableTableManager
                 Value<int> rowid = const Value.absent(),
               }) => PayeeCategoryCacheCompanion(
                 payeeNormalized: payeeNormalized,
+                accountBucket: accountBucket,
                 categoryId: categoryId,
                 confidence: confidence,
                 source: source,
@@ -16821,6 +16891,7 @@ class $$PayeeCategoryCacheTableTableManager
           createCompanionCallback:
               ({
                 required String payeeNormalized,
+                Value<String> accountBucket = const Value.absent(),
                 required String categoryId,
                 required double confidence,
                 required String source,
@@ -16829,6 +16900,7 @@ class $$PayeeCategoryCacheTableTableManager
                 Value<int> rowid = const Value.absent(),
               }) => PayeeCategoryCacheCompanion.insert(
                 payeeNormalized: payeeNormalized,
+                accountBucket: accountBucket,
                 categoryId: categoryId,
                 confidence: confidence,
                 source: source,

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -12,10 +12,19 @@ class AutoCategorizeRepository {
   // PayeeCategoryCache
   // ---------------------------------------------------------------------------
 
-  /// Look up a cached payee → category mapping by normalized payee name.
-  Future<PayeeCategoryCacheData?> getCacheEntry(String payeeNormalized) {
+  /// Look up a cached payee → category mapping.
+  ///
+  /// The cache is partitioned by `accountBucket` so the same payee can have
+  /// different learned categories in 'standard' (checking/credit/savings)
+  /// vs 'investment' (brokerage/401k/IRA/HSA/crypto) contexts.
+  Future<PayeeCategoryCacheData?> getCacheEntry(
+    String payeeNormalized,
+    String accountBucket,
+  ) {
     return (_db.select(_db.payeeCategoryCache)
-          ..where((c) => c.payeeNormalized.equals(payeeNormalized)))
+          ..where((c) =>
+              c.payeeNormalized.equals(payeeNormalized) &
+              c.accountBucket.equals(accountBucket)))
         .getSingleOrNull();
   }
 
@@ -127,5 +136,33 @@ class AutoCategorizeRepository {
   /// Log a user correction (changed category on a transaction).
   Future<void> insertCorrection(CategorizationCorrectionsCompanion correction) {
     return _db.into(_db.categorizationCorrections).insert(correction);
+  }
+
+  /// Count corrections matching a `(normalizePayee(payee), categoryId)` pair
+  /// within the last [days] days.
+  ///
+  /// Pulls all recent rows via SQL (filtered by `createdAt > cutoff` and
+  /// `newCategoryId`) and applies normalization in Dart, since the stored
+  /// `payee` is raw (not normalized) and normalization uses regex logic
+  /// SQLite can't express. Acceptable scale: ~1k rows per 90-day window.
+  Future<int> countRecentCorrectionsForPayee({
+    required String payeeNormalized,
+    required String categoryId,
+    required String Function(String raw) normalizer,
+    int days = 90,
+  }) async {
+    final cutoff = DateTime.now()
+        .subtract(Duration(days: days))
+        .millisecondsSinceEpoch;
+    final rows = await (_db.select(_db.categorizationCorrections)
+          ..where((c) =>
+              c.createdAt.isBiggerThanValue(cutoff) &
+              c.newCategoryId.equals(categoryId)))
+        .get();
+    var count = 0;
+    for (final r in rows) {
+      if (normalizer(r.payee) == payeeNormalized) count++;
+    }
+    return count;
   }
 }

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -1,5 +1,7 @@
 import 'package:drift/drift.dart';
 
+import '../../domain/usecases/categorize/payee_normalization.dart'
+    as payee_norm;
 import '../local/database/app_database.dart';
 
 /// Repository for auto-categorization data: rules, payee cache, and corrections.
@@ -138,17 +140,17 @@ class AutoCategorizeRepository {
     return _db.into(_db.categorizationCorrections).insert(correction);
   }
 
-  /// Count corrections matching a `(normalizePayee(payee), categoryId)` pair
+  /// Count corrections matching `(normalizePayee(payee), categoryId)`
   /// within the last [days] days.
   ///
-  /// Pulls all recent rows via SQL (filtered by `createdAt > cutoff` and
-  /// `newCategoryId`) and applies normalization in Dart, since the stored
-  /// `payee` is raw (not normalized) and normalization uses regex logic
-  /// SQLite can't express. Acceptable scale: ~1k rows per 90-day window.
+  /// Caller passes an already-normalized payee. Internally we apply the
+  /// same normalization to each correction row's raw payee, since the
+  /// stored `payee` is raw and normalization uses regex logic SQLite
+  /// can't express. Acceptable scale: ~1k rows per 90-day window after
+  /// the SQL filter on `createdAt + newCategoryId`.
   Future<int> countRecentCorrectionsForPayee({
     required String payeeNormalized,
     required String categoryId,
-    required String Function(String raw) normalizer,
     int days = 90,
   }) async {
     final cutoff = DateTime.now()
@@ -161,7 +163,7 @@ class AutoCategorizeRepository {
         .get();
     var count = 0;
     for (final r in rows) {
-      if (normalizer(r.payee) == payeeNormalized) count++;
+      if (payee_norm.normalizePayee(r.payee) == payeeNormalized) count++;
     }
     return count;
   }

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -7,6 +7,7 @@ import '../../../data/local/database/app_database.dart';
 import '../../../data/repositories/account_repository.dart';
 import '../../../data/repositories/auto_categorize_repository.dart';
 import '../../../data/repositories/transaction_repository.dart';
+import 'payee_normalization.dart' as payee_norm;
 
 /// Service for automatic transaction categorization.
 ///
@@ -24,84 +25,16 @@ class AutoCategorizeService {
 
   static const _confidenceThreshold = 0.8;
 
-  /// Known POS terminal prefixes to strip from payee names.
-  static final _posPrefixes = [
-    'SQ *',
-    'TST* ',
-    'TST*',
-    'PAYPAL *',
-    'SP * ',
-    'SP *',
-    'CKE*',
-    'DD *',
-    'GOOGLE *',
-    'APL*',
-  ];
-
-  /// Patterns that should be replaced entirely with a canonical name.
-  static final _canonicalReplacements = [
-    (RegExp(r'^AMZN MKTP US\b.*', caseSensitive: false), 'AMAZON'),
-    (RegExp(r'^AMAZON\.COM\b.*', caseSensitive: false), 'AMAZON'),
-    (RegExp(r'^AMZN\b.*', caseSensitive: false), 'AMAZON'),
-  ];
-
-  /// Trailing noise patterns to strip.
-  static final _trailingNoise = RegExp(
-    r'\s*#\d+$'        // trailing reference numbers
-    r'|\s+[A-Z]{2}\s+\d{5}(-\d{4})?$'  // state + zip
-    r'|\s+\d{3}-\d{3}-\d{4}$'          // phone numbers
-  );
-
-  /// Trailing store/location identifiers.
-  static final _trailingStoreId = RegExp(
-    r'\s+(S\d+|ST\d+|T\d+|STORE\s*\d+|LOC\s*\d+|UNIT\s*\d+)$',
-  );
-
-  /// Trailing transaction/reference IDs (6+ chars, must contain both letters
-  /// and digits to avoid stripping real words like SUPERCENTER).
-  static final _trailingRefId = RegExp(r'\s+(?=[A-Z0-9]*[0-9])(?=[A-Z0-9]*[A-Z])[A-Z0-9]{6,}$');
-
-  /// Trailing date-like patterns (MM/DD).
-  static final _trailingDate = RegExp(r'\s+\d{2}/\d{2}$');
-
   // ---------------------------------------------------------------------------
   // Payee normalization
   // ---------------------------------------------------------------------------
 
   /// Normalize a raw payee string for consistent matching.
-  String normalizePayee(String raw) {
-    var s = raw.trim().toUpperCase();
-
-    // Replace canonical patterns first (e.g., AMZN MKTP US* → AMAZON)
-    for (final (pattern, replacement) in _canonicalReplacements) {
-      if (pattern.hasMatch(s)) return replacement;
-    }
-
-    // Strip POS prefixes
-    for (final prefix in _posPrefixes) {
-      if (s.startsWith(prefix.toUpperCase())) {
-        s = s.substring(prefix.length);
-        break;
-      }
-    }
-
-    // Strip trailing noise
-    s = s.replaceAll(_trailingNoise, '');
-
-    // Strip trailing date-like patterns first (exposes store/ref IDs)
-    s = s.replaceAll(_trailingDate, '');
-
-    // Strip trailing store/location identifiers
-    s = s.replaceAll(_trailingStoreId, '');
-
-    // Strip trailing transaction/reference IDs
-    s = s.replaceAll(_trailingRefId, '');
-
-    // Collapse whitespace
-    s = s.replaceAll(RegExp(r'\s+'), ' ').trim();
-
-    return s;
-  }
+  ///
+  /// Delegates to the top-level `normalizePayee` in `payee_normalization.dart`
+  /// so the same logic is reachable from contexts without an
+  /// `AutoCategorizeService` instance (e.g. `RuleSuggestionService`).
+  String normalizePayee(String raw) => payee_norm.normalizePayee(raw);
 
   // ---------------------------------------------------------------------------
   // Similarity matching

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -25,6 +25,29 @@ class AutoCategorizeService {
 
   static const _confidenceThreshold = 0.8;
 
+  /// Account types whose payee semantics differ from everyday spending —
+  /// dividends, transfers in/out, fees. Categorizing STARBUCKS as Coffee in
+  /// a checking account must not bleed into a brokerage account where the
+  /// same payee likely represents a fee or distribution.
+  static const _investmentAccountTypes = {
+    'brokerage',
+    '401k',
+    'ira',
+    'roth_ira',
+    'hsa',
+    'crypto',
+  };
+
+  /// Cache partition key. Two buckets: 'standard' vs 'investment'.
+  /// Investment-vs-not is the only axis where payee semantics actually flip;
+  /// finer-grained partitioning (per accountType) would starve every bucket.
+  static String cacheBucket(String? accountType) {
+    if (accountType == null) return 'standard';
+    return _investmentAccountTypes.contains(accountType)
+        ? 'investment'
+        : 'standard';
+  }
+
   // ---------------------------------------------------------------------------
   // Payee normalization
   // ---------------------------------------------------------------------------
@@ -81,8 +104,9 @@ class AutoCategorizeService {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return null;
 
-    // Tier 1: Payee cache lookup
-    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized);
+    // Tier 1: Payee cache lookup (partitioned by account bucket)
+    final bucket = cacheBucket(accountType);
+    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
       return cacheEntry.categoryId;
     }
@@ -169,8 +193,9 @@ class AutoCategorizeService {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return null;
 
-    // Tier 1: Payee cache lookup (still per-transaction)
-    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized);
+    // Tier 1: Payee cache lookup (partitioned by account bucket)
+    final bucket = cacheBucket(accountType);
+    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
       return cacheEntry.categoryId;
     }
@@ -191,22 +216,29 @@ class AutoCategorizeService {
   // ---------------------------------------------------------------------------
 
   /// Record a user's category assignment to update the payee cache.
+  ///
+  /// [accountType] (optional) determines the cache bucket so investment-account
+  /// learning doesn't bleed into standard-account categorization, and vice
+  /// versa. Null defaults to 'standard'.
   Future<void> recordCategoryAssignment({
     required String payee,
     required String categoryId,
     String? transactionId,
     String? oldCategoryId,
+    String? accountType,
   }) async {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return;
 
     final now = DateTime.now().millisecondsSinceEpoch;
-    final existing = await _autoCatRepo.getCacheEntry(normalized);
+    final bucket = cacheBucket(accountType);
+    final existing = await _autoCatRepo.getCacheEntry(normalized, bucket);
 
     if (existing == null) {
-      // First time seeing this payee
+      // First time seeing this payee in this bucket
       await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
         payeeNormalized: Value(normalized),
+        accountBucket: Value(bucket),
         categoryId: Value(categoryId),
         confidence: const Value(0.5),
         source: const Value('user'),
@@ -219,6 +251,7 @@ class AutoCategorizeService {
       final newConfidence = min(1.0, 0.5 + (newCount * 0.1));
       await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
         payeeNormalized: Value(normalized),
+        accountBucket: Value(bucket),
         categoryId: Value(categoryId),
         confidence: Value(newConfidence),
         source: const Value('user'),
@@ -243,6 +276,7 @@ class AutoCategorizeService {
         final newConfidence = min(1.0, 0.5 + (penalized * 0.1));
         await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
           payeeNormalized: Value(normalized),
+          accountBucket: Value(bucket),
           categoryId: Value(existing.categoryId),
           confidence: Value(newConfidence),
           source: const Value('user'),
@@ -253,6 +287,7 @@ class AutoCategorizeService {
         // useCount was 1; nothing left to keep — adopt the new category.
         await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
           payeeNormalized: Value(normalized),
+          accountBucket: Value(bucket),
           categoryId: Value(categoryId),
           confidence: const Value(0.5),
           source: const Value('user'),

--- a/lib/domain/usecases/categorize/payee_normalization.dart
+++ b/lib/domain/usecases/categorize/payee_normalization.dart
@@ -1,0 +1,84 @@
+/// Payee-name normalization for consistent matching across the
+/// auto-categorization system.
+///
+/// Extracted as a top-level function so it can be used from contexts
+/// that don't have an `AutoCategorizeService` instance — e.g. the
+/// suggested-rule prompt logic in the transaction edit screen and (in
+/// Phase 3) the `RuleSuggestionService`.
+library;
+
+/// Known POS terminal prefixes to strip from payee names.
+final _posPrefixes = [
+  'SQ *',
+  'TST* ',
+  'TST*',
+  'PAYPAL *',
+  'SP * ',
+  'SP *',
+  'CKE*',
+  'DD *',
+  'GOOGLE *',
+  'APL*',
+];
+
+/// Patterns that should be replaced entirely with a canonical name.
+final _canonicalReplacements = [
+  (RegExp(r'^AMZN MKTP US\b.*', caseSensitive: false), 'AMAZON'),
+  (RegExp(r'^AMAZON\.COM\b.*', caseSensitive: false), 'AMAZON'),
+  (RegExp(r'^AMZN\b.*', caseSensitive: false), 'AMAZON'),
+];
+
+/// Trailing noise patterns to strip.
+final _trailingNoise = RegExp(
+  r'\s*#\d+$' // trailing reference numbers
+  r'|\s+[A-Z]{2}\s+\d{5}(-\d{4})?$' // state + zip
+  r'|\s+\d{3}-\d{3}-\d{4}$', // phone numbers
+);
+
+/// Trailing store/location identifiers.
+final _trailingStoreId = RegExp(
+  r'\s+(S\d+|ST\d+|T\d+|STORE\s*\d+|LOC\s*\d+|UNIT\s*\d+)$',
+);
+
+/// Trailing transaction/reference IDs (6+ chars, must contain both letters
+/// and digits to avoid stripping real words like SUPERCENTER).
+final _trailingRefId =
+    RegExp(r'\s+(?=[A-Z0-9]*[0-9])(?=[A-Z0-9]*[A-Z])[A-Z0-9]{6,}$');
+
+/// Trailing date-like patterns (MM/DD).
+final _trailingDate = RegExp(r'\s+\d{2}/\d{2}$');
+
+/// Normalize a raw payee string for consistent matching.
+///
+/// Steps (order matters):
+/// 1. Trim + uppercase
+/// 2. Canonical replacement (e.g. AMZN MKTP US → AMAZON)
+/// 3. POS prefix stripping (SQ *, TST*, PAYPAL *, ...)
+/// 4. Trailing noise stripping (state+zip, phone, ref#)
+/// 5. Trailing date stripping (exposes store/ref IDs underneath)
+/// 6. Trailing store-ID stripping (S123, ST456, LOC 2)
+/// 7. Trailing transaction-ID stripping (6+ alphanumeric, mixed)
+/// 8. Whitespace collapse
+String normalizePayee(String raw) {
+  var s = raw.trim().toUpperCase();
+
+  for (final (pattern, replacement) in _canonicalReplacements) {
+    if (pattern.hasMatch(s)) return replacement;
+  }
+
+  for (final prefix in _posPrefixes) {
+    if (s.startsWith(prefix.toUpperCase())) {
+      s = s.substring(prefix.length);
+      break;
+    }
+  }
+
+  s = s.replaceAll(_trailingNoise, '');
+  s = s.replaceAll(_trailingDate, '');
+  s = s.replaceAll(_trailingStoreId, '');
+  s = s.replaceAll(_trailingRefId, '');
+
+  s = s.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+  return s;
+}

--- a/lib/presentation/features/transactions/add_edit_transaction_screen.dart
+++ b/lib/presentation/features/transactions/add_edit_transaction_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:drift/drift.dart' hide Column;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -81,83 +82,127 @@ class _AddEditTransactionScreenState
   /// (normalizedPayee, categoryId) pair within the last 90 days AND no
   /// enabled rule already covers it, prompt the user to create a
   /// persistent `payeeExact` rule.
+  ///
+  /// Wrapped in try/catch so a failure (DB error, etc.) never aborts the
+  /// surrounding save flow — by the time we get here, the transaction
+  /// has already been persisted and the rule prompt is a nice-to-have.
   Future<void> _maybePromptSuggestRule(
     String payeeText,
     String newCategoryId,
   ) async {
-    const minCorrections = 3;
-    const windowDays = 90;
-    final normalized = payee_norm.normalizePayee(payeeText);
-    if (normalized.isEmpty) return;
+    try {
+      const minCorrections = 3;
+      const windowDays = 90;
+      final normalized = payee_norm.normalizePayee(payeeText);
+      if (normalized.isEmpty) {
+        if (kDebugMode) {
+          debugPrint('[SuggestRule] suppressed: normalized payee is empty');
+        }
+        return;
+      }
 
-    final repo = ref.read(autoCategorizeRepositoryProvider);
-    final count = await repo.countRecentCorrectionsForPayee(
-      payeeNormalized: normalized,
-      categoryId: newCategoryId,
-      normalizer: payee_norm.normalizePayee,
-      days: windowDays,
-    );
-    if (count < minCorrections) return;
-
-    final rules = await repo.getEnabledRules();
-    final alreadyCovered = rules.any((r) {
-      if (r.categoryId != newCategoryId) return false;
-      final pe = r.payeeExact?.toUpperCase();
-      if (pe != null && pe == normalized) return true;
-      final pc = r.payeeContains?.toUpperCase();
-      if (pc != null && normalized.contains(pc)) return true;
-      return false;
-    });
-    if (alreadyCovered) return;
-
-    if (!mounted) return;
-    final categoryName = _selectedCategoryName ?? 'this category';
-    final create = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Always categorize this payee?'),
-        content: Text(
-          'You\'ve set "$normalized" to "$categoryName" $count times in '
-          'the last 90 days. Create a permanent rule so future '
-          'transactions categorize automatically?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Not now'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Create rule'),
-          ),
-        ],
-      ),
-    );
-    if (create != true || !mounted) return;
-
-    final now = DateTime.now().millisecondsSinceEpoch;
-    await repo.insertRule(
-      AutoCategorizeRulesCompanion.insert(
-        id: const Uuid().v4(),
-        name: '$normalized → $categoryName',
-        priority: 100,
-        payeeExact: Value(normalized),
+      final repo = ref.read(autoCategorizeRepositoryProvider);
+      final count = await repo.countRecentCorrectionsForPayee(
+        payeeNormalized: normalized,
         categoryId: newCategoryId,
-        createdAt: now,
-        updatedAt: now,
-      ),
-    );
+        days: windowDays,
+      );
+      if (count < minCorrections) {
+        if (kDebugMode) {
+          debugPrint(
+              '[SuggestRule] suppressed: only $count correction(s) for '
+              '"$normalized" → $newCategoryId (need $minCorrections)');
+        }
+        return;
+      }
+
+      final rules = await repo.getEnabledRules();
+      final alreadyCovered = rules.any((r) {
+        if (r.categoryId != newCategoryId) return false;
+        final pe = r.payeeExact?.toUpperCase();
+        if (pe != null && pe == normalized) return true;
+        final pc = r.payeeContains?.toUpperCase();
+        if (pc != null && normalized.contains(pc)) return true;
+        return false;
+      });
+      if (alreadyCovered) {
+        if (kDebugMode) {
+          debugPrint(
+              '[SuggestRule] suppressed: existing enabled rule already '
+              'covers "$normalized" → $newCategoryId');
+        }
+        return;
+      }
+
+      if (!mounted) return;
+      final categoryName = _selectedCategoryName ?? 'this category';
+      final create = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Always categorize this payee?'),
+          content: Text(
+            'You\'ve assigned "$normalized" to "$categoryName" $count times '
+            '(including this one) in the last $windowDays days. Create a '
+            'permanent rule so future transactions categorize automatically?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Not now'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Create rule'),
+            ),
+          ],
+        ),
+      );
+      if (create != true || !mounted) {
+        if (kDebugMode && create != true) {
+          debugPrint('[SuggestRule] dismissed by user');
+        }
+        return;
+      }
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await repo.insertRule(
+        AutoCategorizeRulesCompanion.insert(
+          id: const Uuid().v4(),
+          name: '$normalized → $categoryName',
+          priority: 100,
+          payeeExact: Value(normalized),
+          categoryId: newCategoryId,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    } catch (e, st) {
+      // Don't propagate — the transaction has already been saved by the
+      // time we get here, so a prompt failure shouldn't tear down the
+      // save flow. Log so QA can diagnose silent failures.
+      if (kDebugMode) {
+        debugPrint('[SuggestRule] error during prompt flow: $e\n$st');
+      }
+    }
   }
 
-  /// Resolve the currently selected account's `accountType`. Returns null
-  /// if no account is selected or lookup fails — callers should default to
-  /// the 'standard' cache bucket in that case.
-  Future<String?> _resolveAccountType() async {
+  /// Resolve the currently selected account's `accountType` synchronously
+  /// from the cached `accountsProvider` snapshot. Returns null if no
+  /// account is selected or the snapshot isn't loaded yet — callers
+  /// should default to the 'standard' cache bucket in that case.
+  ///
+  /// We deliberately avoid an async DB roundtrip here because this method
+  /// is called from `_onPayeeChanged` (every 300ms during typing) and the
+  /// account list is already watched by the screen's build method.
+  String? _resolveAccountType() {
     final id = _selectedAccountId;
     if (id == null) return null;
-    final account =
-        await ref.read(accountRepositoryProvider).getAccountById(id);
-    return account?.accountType;
+    final accounts = ref.read(accountsProvider).valueOrNull;
+    if (accounts == null) return null;
+    for (final a in accounts) {
+      if (a.id == id) return a.accountType;
+    }
+    return null;
   }
 
   void _onPayeeChanged() {
@@ -171,7 +216,7 @@ class _AddEditTransactionScreenState
       // matches the user's account context — STARBUCKS in a brokerage
       // account should not auto-suggest Coffee from the checking-account
       // cache, and vice versa.
-      final accountType = await _resolveAccountType();
+      final accountType = _resolveAccountType();
       final categoryId =
           await service.categorize(text, accountType: accountType);
       if (categoryId != null && _selectedCategoryId == null && mounted) {
@@ -276,7 +321,7 @@ class _AddEditTransactionScreenState
       final payeeText = _payeeController.text.trim();
       final autoCatService = ref.read(autoCategorizeServiceProvider);
       if (_selectedCategoryId != null && payeeText.isNotEmpty) {
-        final accountType = await _resolveAccountType();
+        final accountType = _resolveAccountType();
         await autoCatService.recordCategoryAssignment(
           payee: payeeText,
           categoryId: _selectedCategoryId!,

--- a/lib/presentation/features/transactions/add_edit_transaction_screen.dart
+++ b/lib/presentation/features/transactions/add_edit_transaction_screen.dart
@@ -11,6 +11,8 @@ import '../../../core/di/providers.dart';
 import '../../../core/extensions/money_extensions.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../data/local/database/models.dart';
+import '../../../domain/usecases/categorize/payee_normalization.dart'
+    as payee_norm;
 import '../../shared/utils/snackbar_helpers.dart';
 import '../../shared/widgets/category_picker_sheet.dart';
 import '../../shared/widgets/delete_confirmation_dialog.dart';
@@ -75,6 +77,89 @@ class _AddEditTransactionScreenState
     super.dispose();
   }
 
+  /// When a correction has been made N+ times for the same
+  /// (normalizedPayee, categoryId) pair within the last 90 days AND no
+  /// enabled rule already covers it, prompt the user to create a
+  /// persistent `payeeExact` rule.
+  Future<void> _maybePromptSuggestRule(
+    String payeeText,
+    String newCategoryId,
+  ) async {
+    const minCorrections = 3;
+    const windowDays = 90;
+    final normalized = payee_norm.normalizePayee(payeeText);
+    if (normalized.isEmpty) return;
+
+    final repo = ref.read(autoCategorizeRepositoryProvider);
+    final count = await repo.countRecentCorrectionsForPayee(
+      payeeNormalized: normalized,
+      categoryId: newCategoryId,
+      normalizer: payee_norm.normalizePayee,
+      days: windowDays,
+    );
+    if (count < minCorrections) return;
+
+    final rules = await repo.getEnabledRules();
+    final alreadyCovered = rules.any((r) {
+      if (r.categoryId != newCategoryId) return false;
+      final pe = r.payeeExact?.toUpperCase();
+      if (pe != null && pe == normalized) return true;
+      final pc = r.payeeContains?.toUpperCase();
+      if (pc != null && normalized.contains(pc)) return true;
+      return false;
+    });
+    if (alreadyCovered) return;
+
+    if (!mounted) return;
+    final categoryName = _selectedCategoryName ?? 'this category';
+    final create = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Always categorize this payee?'),
+        content: Text(
+          'You\'ve set "$normalized" to "$categoryName" $count times in '
+          'the last 90 days. Create a permanent rule so future '
+          'transactions categorize automatically?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Not now'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Create rule'),
+          ),
+        ],
+      ),
+    );
+    if (create != true || !mounted) return;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await repo.insertRule(
+      AutoCategorizeRulesCompanion.insert(
+        id: const Uuid().v4(),
+        name: '$normalized → $categoryName',
+        priority: 100,
+        payeeExact: Value(normalized),
+        categoryId: newCategoryId,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  /// Resolve the currently selected account's `accountType`. Returns null
+  /// if no account is selected or lookup fails — callers should default to
+  /// the 'standard' cache bucket in that case.
+  Future<String?> _resolveAccountType() async {
+    final id = _selectedAccountId;
+    if (id == null) return null;
+    final account =
+        await ref.read(accountRepositoryProvider).getAccountById(id);
+    return account?.accountType;
+  }
+
   void _onPayeeChanged() {
     _payeeSuggestionTimer?.cancel();
     if (_selectedCategoryId != null) return; // user already picked
@@ -82,7 +167,13 @@ class _AddEditTransactionScreenState
     if (text.length < 3) return;
     _payeeSuggestionTimer = Timer(const Duration(milliseconds: 300), () async {
       final service = ref.read(autoCategorizeServiceProvider);
-      final categoryId = await service.categorize(text);
+      // Pass accountType so the cache bucket (standard vs investment)
+      // matches the user's account context — STARBUCKS in a brokerage
+      // account should not auto-suggest Coffee from the checking-account
+      // cache, and vice versa.
+      final accountType = await _resolveAccountType();
+      final categoryId =
+          await service.categorize(text, accountType: accountType);
       if (categoryId != null && _selectedCategoryId == null && mounted) {
         final category = await ref
             .read(categoryRepositoryProvider)
@@ -185,12 +276,23 @@ class _AddEditTransactionScreenState
       final payeeText = _payeeController.text.trim();
       final autoCatService = ref.read(autoCategorizeServiceProvider);
       if (_selectedCategoryId != null && payeeText.isNotEmpty) {
+        final accountType = await _resolveAccountType();
         await autoCatService.recordCategoryAssignment(
           payee: payeeText,
           categoryId: _selectedCategoryId!,
           transactionId: _isEditing ? widget.transaction!.id : null,
           oldCategoryId: _isEditing ? widget.transaction!.categoryId : null,
+          accountType: accountType,
         );
+
+        // If this was a correction (edit changing the category) and the
+        // same (normalizedPayee, newCategoryId) pair has been corrected
+        // N+ times within the recent window, prompt the user to create a
+        // persistent rule.
+        if (_isEditing &&
+            widget.transaction!.categoryId != _selectedCategoryId) {
+          await _maybePromptSuggestRule(payeeText, _selectedCategoryId!);
+        }
       }
 
       if (!mounted) return;

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -202,7 +202,7 @@ void main() {
 
   group('categorize', () {
     test('returns categoryId from cache when confidence >= 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -216,7 +216,7 @@ void main() {
     });
 
     test('falls through to rules when cache confidence < 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -232,7 +232,7 @@ void main() {
     });
 
     test('returns null when no cache entry and no rules match', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => []);
@@ -242,7 +242,7 @@ void main() {
     });
 
     test('matches rule with payeeContains', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER'))
+      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -260,7 +260,7 @@ void main() {
     });
 
     test('matches rule with payeeExact', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('NETFLIX'))
+      when(() => mockAutoCatRepo.getCacheEntry('NETFLIX', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -278,7 +278,7 @@ void main() {
     });
 
     test('respects rule priority order (first match wins)', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -302,7 +302,7 @@ void main() {
     });
 
     test('rule with amount range filters correctly', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('STORE', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -331,7 +331,7 @@ void main() {
 
   group('recordCategoryAssignment', () {
     test('creates new cache entry for unknown payee', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -352,7 +352,7 @@ void main() {
     });
 
     test('increments useCount for same category', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -380,7 +380,7 @@ void main() {
         'mismatch on useCount=1 entry adopts new category at baseline (flip)',
         () async {
       // useCount=1 means no learning to protect; new category wins.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -411,7 +411,7 @@ void main() {
       // Boundary case: useCount=2 means penalized=1, which is exactly the
       // >= 1 threshold. A regression that flips the check to > 1 would
       // silently flip useCount=2 entries instead of keeping them.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -441,7 +441,7 @@ void main() {
         () async {
       // When dominance-keep preserves the old categoryId, the correction
       // log must still record the user's actual choice for audit purposes.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -482,7 +482,7 @@ void main() {
       // misclick demotes it to useCount=2/confidence=0.7 — falls below
       // threshold so the user is prompted next time, but learning is
       // preserved.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -513,7 +513,7 @@ void main() {
         () async {
       // High-confidence stability: a strong learning signal isn't wiped by
       // one misclick.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -539,7 +539,7 @@ void main() {
     });
 
     test('logs correction when oldCategoryId differs', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -557,7 +557,7 @@ void main() {
     });
 
     test('does not log correction when category unchanged', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -575,7 +575,7 @@ void main() {
 
   group('categorizeWithPreloadedRules', () {
     test('returns categoryId from cache when confidence >= 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -602,7 +602,7 @@ void main() {
     });
 
     test('matches preloaded rules when cache misses', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER'))
+      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER', 'standard'))
           .thenAnswer((_) async => null);
 
       final rules = [
@@ -623,7 +623,7 @@ void main() {
     });
 
     test('returns null when no cache and no rules match', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE', 'standard'))
           .thenAnswer((_) async => null);
 
       final rules = [
@@ -653,7 +653,7 @@ void main() {
       ];
 
       // Setup mocks for both paths
-      when(() => mockAutoCatRepo.getCacheEntry('TARGET'))
+      when(() => mockAutoCatRepo.getCacheEntry('TARGET', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => rules);
@@ -694,7 +694,7 @@ void main() {
           .thenAnswer((_) async => txns);
 
       // Starbucks matches cache
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -703,7 +703,7 @@ void main() {
       );
 
       // Unknown Store has no match
-      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => []);
@@ -758,7 +758,7 @@ void main() {
       when(() => mockAccountRepo.getAllAccounts()).thenAnswer(
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
-      when(() => mockAutoCatRepo.getCacheEntry('DIV - ISHARES RUSSELL 1000'))
+      when(() => mockAutoCatRepo.getCacheEntry('DIV - ISHARES RUSSELL 1000', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -794,8 +794,11 @@ void main() {
 
       when(() => mockTxnRepo.getUncategorizedTransactions())
           .thenAnswer((_) async => txns);
+      // Without accountRepo, accountType resolves to null → 'standard'
+      // bucket. The investment rule won't match because we lack account
+      // context.
       when(() => mockAutoCatRepo.getCacheEntry(
-              'RECORDKEEPING FEE-WELLINGTON'))
+              'RECORDKEEPING FEE-WELLINGTON', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -831,7 +834,7 @@ void main() {
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
       when(() => mockAutoCatRepo.getCacheEntry(
-              'IQPA AUDIT FEES-FIDELITY MID CAP INDEX'))
+              'IQPA AUDIT FEES-FIDELITY MID CAP INDEX', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -870,7 +873,7 @@ void main() {
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
       when(() => mockAutoCatRepo.getCacheEntry(
-              'TRANSFERS IN/OUT-FIDELITY 500 INDEX FUND'))
+              'TRANSFERS IN/OUT-FIDELITY 500 INDEX FUND', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -909,7 +912,8 @@ void main() {
         (_) async =>
             [_makeAccount(id: 'acc-checking', accountType: 'checking')],
       );
-      when(() => mockAutoCatRepo.getCacheEntry('DIV - VANGUARD FUND'))
+      // Checking account → 'standard' bucket
+      when(() => mockAutoCatRepo.getCacheEntry('DIV - VANGUARD FUND', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -927,6 +931,122 @@ void main() {
 
       expect(count, equals(0));
       verifyNever(() => mockTxnRepo.updateCategory(any(), any()));
+    });
+  });
+
+  group('account-bucket cache isolation', () {
+    test('cacheBucket maps investment account types to investment', () {
+      expect(AutoCategorizeService.cacheBucket('brokerage'),
+          equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('401k'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('ira'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('roth_ira'),
+          equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('hsa'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('crypto'), equals('investment'));
+    });
+
+    test('cacheBucket maps non-investment account types to standard', () {
+      expect(AutoCategorizeService.cacheBucket('checking'), equals('standard'));
+      expect(AutoCategorizeService.cacheBucket('savings'), equals('standard'));
+      expect(AutoCategorizeService.cacheBucket('credit_card'),
+          equals('standard'));
+    });
+
+    test('cacheBucket defaults to standard for null accountType', () {
+      expect(AutoCategorizeService.cacheBucket(null), equals('standard'));
+    });
+
+    test('categorize uses investment bucket when accountType is 401k', () async {
+      // Standard bucket entry exists with high confidence, but the call is
+      // for a 401k account — the lookup should target the investment bucket
+      // and miss, falling through to rules (which we leave empty).
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => []);
+
+      final result =
+          await service.categorize('Starbucks', accountType: '401k');
+
+      expect(result, isNull);
+      verify(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .called(1);
+      verifyNever(
+          () => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'));
+    });
+
+    test(
+        'categorize hits separate cache entries per bucket for same payee',
+        () async {
+      // Two different cache entries: STARBUCKS in standard → Coffee, in
+      // investment → Investment Fees. Each call hits the correct row.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          accountBucket: 'standard',
+          categoryId: 'cat-coffee',
+          confidence: 0.9,
+          useCount: 5,
+        ),
+      );
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          accountBucket: 'investment',
+          categoryId: 'cat-fees',
+          confidence: 0.9,
+          useCount: 5,
+        ),
+      );
+
+      final checkingResult =
+          await service.categorize('Starbucks', accountType: 'checking');
+      final brokerageResult =
+          await service.categorize('Starbucks', accountType: 'brokerage');
+
+      expect(checkingResult, equals('cat-coffee'));
+      expect(brokerageResult, equals('cat-fees'));
+    });
+
+    test('recordCategoryAssignment writes to bucket derived from accountType',
+        () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-fees',
+        accountType: 'brokerage',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(captured.accountBucket.value, equals('investment'));
+      expect(captured.payeeNormalized.value, equals('STARBUCKS'));
+    });
+
+    test('recordCategoryAssignment defaults to standard bucket when '
+        'accountType is null', () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-coffee',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(captured.accountBucket.value, equals('standard'));
     });
   });
 
@@ -1000,11 +1120,13 @@ PayeeCategoryCacheData _makeCacheEntry({
   required String payeeNormalized,
   required String categoryId,
   required double confidence,
+  String accountBucket = 'standard',
   String source = 'user',
   int useCount = 1,
 }) {
   return PayeeCategoryCacheData(
     payeeNormalized: payeeNormalized,
+    accountBucket: accountBucket,
     categoryId: categoryId,
     confidence: confidence,
     source: source,


### PR DESCRIPTION
## Summary

Phase 2 of auto-categorization improvements (depends on PR #142). Adds account-aware cache partitioning and a user-facing suggested-rule prompt. **Base intentionally set to `feature/auto-categorize-phase-1` so the diff shows only Phase 2 work** — GitHub will auto-update the base to `master` after #142 merges.

Includes one schema migration (v6 → v7) and 7 new tests. 326 tests pass total.

## Changes

- **2.A** (WIP commit): Extract `normalizePayee` to a top-level function in `lib/domain/usecases/categorize/payee_normalization.dart` so it's reachable without an `AutoCategorizeService` instance.
- **2.B** (WIP commit): Schema migration v6 → v7. `PayeeCategoryCache` now has composite PK `(payee_normalized, account_bucket)`. Migration uses the table-rebuild pattern (SQLite can't redefine PK in place). Existing rows default to `'standard'` bucket.
- **2.C**: Thread `accountBucket` through service + call sites. Two buckets (standard / investment), not raw `accountType` — finer granularity would starve every bucket.
  - `categorize()`, `categorizeWithPreloadedRules()`, `recordCategoryAssignment()` all derive bucket and pass to cache lookup.
  - `add_edit_transaction_screen.dart` threads `accountType` through both the real-time `_onPayeeChanged` suggestion AND the `recordCategoryAssignment` save handler.
- **2.D**: `countRecentCorrectionsForPayee` repo method. SQL-filter by `createdAt > cutoff` AND `newCategoryId`, then filter by normalized payee in Dart.
- **2.E**: 3rd-correction "Create rule?" prompt. After an edit changing category: if count ≥ 3 in last 90 days AND no enabled rule covers it, show dialog. Tap creates a `payeeExact` rule at priority 100.

## Test plan

- [x] `flutter analyze` clean on all touched files
- [x] `flutter test` passes (326/326)
- [ ] Migration smoke: real v6 DB upgrades cleanly, existing cache rows readable as `'standard'` bucket
- [ ] Cache isolation: categorize STARBUCKS as Coffee in checking → add STARBUCKS transaction in brokerage → confirm it does NOT auto-categorize. Categorize as Investment Fees. Future STARBUCKS in brokerage → Investment Fees; future STARBUCKS in checking → still Coffee.
- [ ] Real-time suggestion honors account context (STARBUCKS in brokerage suggests Investment Fees, not Coffee)
- [ ] 3rd-correction prompt: correct PELOTON → Subscriptions on 3 transactions; 3rd save triggers "Always categorize?" dialog; tap "Create rule" → rule appears in rules screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)