### PR TITLE
feat(categorize): 3.1 — test-a-payee debug panel + trace refactor

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -40,7 +40,7 @@ class DefaultCategories {
 
   static const List<Map<String, dynamic>> expense = [
     {'name': 'Housing', 'icon': 'home', 'color': 0xFF5C6BC0, 'children': ['Rent/Mortgage', 'Utilities', 'Maintenance', 'Insurance']},
-    {'name': 'Transportation', 'icon': 'directions_car', 'color': 0xFF42A5F5, 'children': ['Gas', 'Auto Payment', 'Auto Insurance', 'Parking', 'Public Transit']},
+    {'name': 'Transportation', 'icon': 'directions_car', 'color': 0xFF42A5F5, 'children': ['Gas', 'Auto Payment', 'Auto Insurance', 'Auto Maintenance', 'Parking', 'Public Transit']},
     {'name': 'Groceries', 'icon': 'shopping_cart', 'color': 0xFF66BB6A, 'children': <String>[]},
     {'name': 'Dining', 'icon': 'restaurant', 'color': 0xFFEF5350, 'children': ['Restaurants', 'Coffee Shops', 'Fast Food', 'Delivery']},
     {'name': 'Shopping', 'icon': 'shopping_bag', 'color': 0xFFAB47BC, 'children': ['Clothing', 'Electronics', 'Home Goods']},

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -214,8 +214,15 @@ class RecurringTransactions extends Table {
 // =============================================================================
 
 /// Tier 1: payee → category lookup cache.
+///
+/// `accountBucket` partitions the cache into 'standard' (checking, savings,
+/// credit cards) vs 'investment' (brokerage, 401k, IRA, HSA, crypto). The
+/// same payee can have different semantics across the two — e.g. STARBUCKS
+/// is Coffee Shops in checking but Investment Fees in a brokerage account.
 class PayeeCategoryCache extends Table {
   TextColumn get payeeNormalized => text()();
+  TextColumn get accountBucket =>
+      text().withDefault(const Constant('standard'))();
   TextColumn get categoryId => text()();
   RealColumn get confidence => real()();
   TextColumn get source => text()();
@@ -223,7 +230,7 @@ class PayeeCategoryCache extends Table {
   IntColumn get updatedAt => integer()();
 
   @override
-  Set<Column> get primaryKey => {payeeNormalized};
+  Set<Column> get primaryKey => {payeeNormalized, accountBucket};
 }
 
 /// User correction history for categorization learning.
@@ -410,7 +417,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -518,6 +525,38 @@ class AppDatabase extends _$AppDatabase {
           if (from < 6) {
             await customStatement(
               'ALTER TABLE auto_categorize_rules ADD COLUMN account_type TEXT',
+            );
+          }
+
+          // v6 → v7: Add accountBucket to PayeeCategoryCache with composite PK
+          // (payee_normalized, account_bucket). SQLite cannot redefine a
+          // primary key in place — use the table-rebuild pattern. Existing
+          // rows default to 'standard' (non-investment) which matches the
+          // historic single-bucket behavior.
+          if (from < 7) {
+            await customStatement('''
+              CREATE TABLE payee_category_cache_new (
+                payee_normalized TEXT NOT NULL,
+                account_bucket TEXT NOT NULL DEFAULT 'standard',
+                category_id TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                source TEXT NOT NULL,
+                use_count INTEGER NOT NULL DEFAULT 1,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (payee_normalized, account_bucket)
+              )
+            ''');
+            await customStatement('''
+              INSERT INTO payee_category_cache_new
+                (payee_normalized, account_bucket, category_id, confidence,
+                 source, use_count, updated_at)
+              SELECT payee_normalized, 'standard', category_id, confidence,
+                     source, use_count, updated_at
+              FROM payee_category_cache
+            ''');
+            await customStatement('DROP TABLE payee_category_cache');
+            await customStatement(
+              'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
             );
           }
         },

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -533,31 +533,37 @@ class AppDatabase extends _$AppDatabase {
           // primary key in place — use the table-rebuild pattern. Existing
           // rows default to 'standard' (non-investment) which matches the
           // historic single-bucket behavior.
+          //
+          // Drift wraps onUpgrade in a transaction by default; the explicit
+          // transaction() here makes the atomicity intent legible to anyone
+          // scanning the migration and protects against future Drift changes.
           if (from < 7) {
-            await customStatement('''
-              CREATE TABLE payee_category_cache_new (
-                payee_normalized TEXT NOT NULL,
-                account_bucket TEXT NOT NULL DEFAULT 'standard',
-                category_id TEXT NOT NULL,
-                confidence REAL NOT NULL,
-                source TEXT NOT NULL,
-                use_count INTEGER NOT NULL DEFAULT 1,
-                updated_at INTEGER NOT NULL,
-                PRIMARY KEY (payee_normalized, account_bucket)
-              )
-            ''');
-            await customStatement('''
-              INSERT INTO payee_category_cache_new
-                (payee_normalized, account_bucket, category_id, confidence,
-                 source, use_count, updated_at)
-              SELECT payee_normalized, 'standard', category_id, confidence,
-                     source, use_count, updated_at
-              FROM payee_category_cache
-            ''');
-            await customStatement('DROP TABLE payee_category_cache');
-            await customStatement(
-              'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
-            );
+            await transaction(() async {
+              await customStatement('''
+                CREATE TABLE payee_category_cache_new (
+                  payee_normalized TEXT NOT NULL,
+                  account_bucket TEXT NOT NULL DEFAULT 'standard',
+                  category_id TEXT NOT NULL,
+                  confidence REAL NOT NULL,
+                  source TEXT NOT NULL,
+                  use_count INTEGER NOT NULL DEFAULT 1,
+                  updated_at INTEGER NOT NULL,
+                  PRIMARY KEY (payee_normalized, account_bucket)
+                )
+              ''');
+              await customStatement('''
+                INSERT INTO payee_category_cache_new
+                  (payee_normalized, account_bucket, category_id, confidence,
+                   source, use_count, updated_at)
+                SELECT payee_normalized, 'standard', category_id, confidence,
+                       source, use_count, updated_at
+                FROM payee_category_cache
+              ''');
+              await customStatement('DROP TABLE payee_category_cache');
+              await customStatement(
+                'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
+              );
+            });
           }
         },
         beforeOpen: (details) async {

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -7844,6 +7844,18 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _accountBucketMeta = const VerificationMeta(
+    'accountBucket',
+  );
+  @override
+  late final GeneratedColumn<String> accountBucket = GeneratedColumn<String>(
+    'account_bucket',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('standard'),
+  );
   static const VerificationMeta _categoryIdMeta = const VerificationMeta(
     'categoryId',
   );
@@ -7901,6 +7913,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
   @override
   List<GeneratedColumn> get $columns => [
     payeeNormalized,
+    accountBucket,
     categoryId,
     confidence,
     source,
@@ -7929,6 +7942,15 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
       );
     } else if (isInserting) {
       context.missing(_payeeNormalizedMeta);
+    }
+    if (data.containsKey('account_bucket')) {
+      context.handle(
+        _accountBucketMeta,
+        accountBucket.isAcceptableOrUnknown(
+          data['account_bucket']!,
+          _accountBucketMeta,
+        ),
+      );
     }
     if (data.containsKey('category_id')) {
       context.handle(
@@ -7972,7 +7994,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {payeeNormalized};
+  Set<GeneratedColumn> get $primaryKey => {payeeNormalized, accountBucket};
   @override
   PayeeCategoryCacheData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
@@ -7980,6 +8002,10 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
       payeeNormalized: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}payee_normalized'],
+      )!,
+      accountBucket: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}account_bucket'],
       )!,
       categoryId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -8013,6 +8039,7 @@ class $PayeeCategoryCacheTable extends PayeeCategoryCache
 class PayeeCategoryCacheData extends DataClass
     implements Insertable<PayeeCategoryCacheData> {
   final String payeeNormalized;
+  final String accountBucket;
   final String categoryId;
   final double confidence;
   final String source;
@@ -8020,6 +8047,7 @@ class PayeeCategoryCacheData extends DataClass
   final int updatedAt;
   const PayeeCategoryCacheData({
     required this.payeeNormalized,
+    required this.accountBucket,
     required this.categoryId,
     required this.confidence,
     required this.source,
@@ -8030,6 +8058,7 @@ class PayeeCategoryCacheData extends DataClass
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['payee_normalized'] = Variable<String>(payeeNormalized);
+    map['account_bucket'] = Variable<String>(accountBucket);
     map['category_id'] = Variable<String>(categoryId);
     map['confidence'] = Variable<double>(confidence);
     map['source'] = Variable<String>(source);
@@ -8041,6 +8070,7 @@ class PayeeCategoryCacheData extends DataClass
   PayeeCategoryCacheCompanion toCompanion(bool nullToAbsent) {
     return PayeeCategoryCacheCompanion(
       payeeNormalized: Value(payeeNormalized),
+      accountBucket: Value(accountBucket),
       categoryId: Value(categoryId),
       confidence: Value(confidence),
       source: Value(source),
@@ -8056,6 +8086,7 @@ class PayeeCategoryCacheData extends DataClass
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return PayeeCategoryCacheData(
       payeeNormalized: serializer.fromJson<String>(json['payeeNormalized']),
+      accountBucket: serializer.fromJson<String>(json['accountBucket']),
       categoryId: serializer.fromJson<String>(json['categoryId']),
       confidence: serializer.fromJson<double>(json['confidence']),
       source: serializer.fromJson<String>(json['source']),
@@ -8068,6 +8099,7 @@ class PayeeCategoryCacheData extends DataClass
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'payeeNormalized': serializer.toJson<String>(payeeNormalized),
+      'accountBucket': serializer.toJson<String>(accountBucket),
       'categoryId': serializer.toJson<String>(categoryId),
       'confidence': serializer.toJson<double>(confidence),
       'source': serializer.toJson<String>(source),
@@ -8078,6 +8110,7 @@ class PayeeCategoryCacheData extends DataClass
 
   PayeeCategoryCacheData copyWith({
     String? payeeNormalized,
+    String? accountBucket,
     String? categoryId,
     double? confidence,
     String? source,
@@ -8085,6 +8118,7 @@ class PayeeCategoryCacheData extends DataClass
     int? updatedAt,
   }) => PayeeCategoryCacheData(
     payeeNormalized: payeeNormalized ?? this.payeeNormalized,
+    accountBucket: accountBucket ?? this.accountBucket,
     categoryId: categoryId ?? this.categoryId,
     confidence: confidence ?? this.confidence,
     source: source ?? this.source,
@@ -8096,6 +8130,9 @@ class PayeeCategoryCacheData extends DataClass
       payeeNormalized: data.payeeNormalized.present
           ? data.payeeNormalized.value
           : this.payeeNormalized,
+      accountBucket: data.accountBucket.present
+          ? data.accountBucket.value
+          : this.accountBucket,
       categoryId: data.categoryId.present
           ? data.categoryId.value
           : this.categoryId,
@@ -8112,6 +8149,7 @@ class PayeeCategoryCacheData extends DataClass
   String toString() {
     return (StringBuffer('PayeeCategoryCacheData(')
           ..write('payeeNormalized: $payeeNormalized, ')
+          ..write('accountBucket: $accountBucket, ')
           ..write('categoryId: $categoryId, ')
           ..write('confidence: $confidence, ')
           ..write('source: $source, ')
@@ -8124,6 +8162,7 @@ class PayeeCategoryCacheData extends DataClass
   @override
   int get hashCode => Object.hash(
     payeeNormalized,
+    accountBucket,
     categoryId,
     confidence,
     source,
@@ -8135,6 +8174,7 @@ class PayeeCategoryCacheData extends DataClass
       identical(this, other) ||
       (other is PayeeCategoryCacheData &&
           other.payeeNormalized == this.payeeNormalized &&
+          other.accountBucket == this.accountBucket &&
           other.categoryId == this.categoryId &&
           other.confidence == this.confidence &&
           other.source == this.source &&
@@ -8145,6 +8185,7 @@ class PayeeCategoryCacheData extends DataClass
 class PayeeCategoryCacheCompanion
     extends UpdateCompanion<PayeeCategoryCacheData> {
   final Value<String> payeeNormalized;
+  final Value<String> accountBucket;
   final Value<String> categoryId;
   final Value<double> confidence;
   final Value<String> source;
@@ -8153,6 +8194,7 @@ class PayeeCategoryCacheCompanion
   final Value<int> rowid;
   const PayeeCategoryCacheCompanion({
     this.payeeNormalized = const Value.absent(),
+    this.accountBucket = const Value.absent(),
     this.categoryId = const Value.absent(),
     this.confidence = const Value.absent(),
     this.source = const Value.absent(),
@@ -8162,6 +8204,7 @@ class PayeeCategoryCacheCompanion
   });
   PayeeCategoryCacheCompanion.insert({
     required String payeeNormalized,
+    this.accountBucket = const Value.absent(),
     required String categoryId,
     required double confidence,
     required String source,
@@ -8175,6 +8218,7 @@ class PayeeCategoryCacheCompanion
        updatedAt = Value(updatedAt);
   static Insertable<PayeeCategoryCacheData> custom({
     Expression<String>? payeeNormalized,
+    Expression<String>? accountBucket,
     Expression<String>? categoryId,
     Expression<double>? confidence,
     Expression<String>? source,
@@ -8184,6 +8228,7 @@ class PayeeCategoryCacheCompanion
   }) {
     return RawValuesInsertable({
       if (payeeNormalized != null) 'payee_normalized': payeeNormalized,
+      if (accountBucket != null) 'account_bucket': accountBucket,
       if (categoryId != null) 'category_id': categoryId,
       if (confidence != null) 'confidence': confidence,
       if (source != null) 'source': source,
@@ -8195,6 +8240,7 @@ class PayeeCategoryCacheCompanion
 
   PayeeCategoryCacheCompanion copyWith({
     Value<String>? payeeNormalized,
+    Value<String>? accountBucket,
     Value<String>? categoryId,
     Value<double>? confidence,
     Value<String>? source,
@@ -8204,6 +8250,7 @@ class PayeeCategoryCacheCompanion
   }) {
     return PayeeCategoryCacheCompanion(
       payeeNormalized: payeeNormalized ?? this.payeeNormalized,
+      accountBucket: accountBucket ?? this.accountBucket,
       categoryId: categoryId ?? this.categoryId,
       confidence: confidence ?? this.confidence,
       source: source ?? this.source,
@@ -8218,6 +8265,9 @@ class PayeeCategoryCacheCompanion
     final map = <String, Expression>{};
     if (payeeNormalized.present) {
       map['payee_normalized'] = Variable<String>(payeeNormalized.value);
+    }
+    if (accountBucket.present) {
+      map['account_bucket'] = Variable<String>(accountBucket.value);
     }
     if (categoryId.present) {
       map['category_id'] = Variable<String>(categoryId.value);
@@ -8244,6 +8294,7 @@ class PayeeCategoryCacheCompanion
   String toString() {
     return (StringBuffer('PayeeCategoryCacheCompanion(')
           ..write('payeeNormalized: $payeeNormalized, ')
+          ..write('accountBucket: $accountBucket, ')
           ..write('categoryId: $categoryId, ')
           ..write('confidence: $confidence, ')
           ..write('source: $source, ')
@@ -16630,6 +16681,7 @@ typedef $$RecurringTransactionsTableProcessedTableManager =
 typedef $$PayeeCategoryCacheTableCreateCompanionBuilder =
     PayeeCategoryCacheCompanion Function({
       required String payeeNormalized,
+      Value<String> accountBucket,
       required String categoryId,
       required double confidence,
       required String source,
@@ -16640,6 +16692,7 @@ typedef $$PayeeCategoryCacheTableCreateCompanionBuilder =
 typedef $$PayeeCategoryCacheTableUpdateCompanionBuilder =
     PayeeCategoryCacheCompanion Function({
       Value<String> payeeNormalized,
+      Value<String> accountBucket,
       Value<String> categoryId,
       Value<double> confidence,
       Value<String> source,
@@ -16659,6 +16712,11 @@ class $$PayeeCategoryCacheTableFilterComposer
   });
   ColumnFilters<String> get payeeNormalized => $composableBuilder(
     column: $table.payeeNormalized,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -16702,6 +16760,11 @@ class $$PayeeCategoryCacheTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get categoryId => $composableBuilder(
     column: $table.categoryId,
     builder: (column) => ColumnOrderings(column),
@@ -16739,6 +16802,11 @@ class $$PayeeCategoryCacheTableAnnotationComposer
   });
   GeneratedColumn<String> get payeeNormalized => $composableBuilder(
     column: $table.payeeNormalized,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get accountBucket => $composableBuilder(
+    column: $table.accountBucket,
     builder: (column) => column,
   );
 
@@ -16803,6 +16871,7 @@ class $$PayeeCategoryCacheTableTableManager
           updateCompanionCallback:
               ({
                 Value<String> payeeNormalized = const Value.absent(),
+                Value<String> accountBucket = const Value.absent(),
                 Value<String> categoryId = const Value.absent(),
                 Value<double> confidence = const Value.absent(),
                 Value<String> source = const Value.absent(),
@@ -16811,6 +16880,7 @@ class $$PayeeCategoryCacheTableTableManager
                 Value<int> rowid = const Value.absent(),
               }) => PayeeCategoryCacheCompanion(
                 payeeNormalized: payeeNormalized,
+                accountBucket: accountBucket,
                 categoryId: categoryId,
                 confidence: confidence,
                 source: source,
@@ -16821,6 +16891,7 @@ class $$PayeeCategoryCacheTableTableManager
           createCompanionCallback:
               ({
                 required String payeeNormalized,
+                Value<String> accountBucket = const Value.absent(),
                 required String categoryId,
                 required double confidence,
                 required String source,
@@ -16829,6 +16900,7 @@ class $$PayeeCategoryCacheTableTableManager
                 Value<int> rowid = const Value.absent(),
               }) => PayeeCategoryCacheCompanion.insert(
                 payeeNormalized: payeeNormalized,
+                accountBucket: accountBucket,
                 categoryId: categoryId,
                 confidence: confidence,
                 source: source,

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -12,10 +12,19 @@ class AutoCategorizeRepository {
   // PayeeCategoryCache
   // ---------------------------------------------------------------------------
 
-  /// Look up a cached payee → category mapping by normalized payee name.
-  Future<PayeeCategoryCacheData?> getCacheEntry(String payeeNormalized) {
+  /// Look up a cached payee → category mapping.
+  ///
+  /// The cache is partitioned by `accountBucket` so the same payee can have
+  /// different learned categories in 'standard' (checking/credit/savings)
+  /// vs 'investment' (brokerage/401k/IRA/HSA/crypto) contexts.
+  Future<PayeeCategoryCacheData?> getCacheEntry(
+    String payeeNormalized,
+    String accountBucket,
+  ) {
     return (_db.select(_db.payeeCategoryCache)
-          ..where((c) => c.payeeNormalized.equals(payeeNormalized)))
+          ..where((c) =>
+              c.payeeNormalized.equals(payeeNormalized) &
+              c.accountBucket.equals(accountBucket)))
         .getSingleOrNull();
   }
 
@@ -127,5 +136,33 @@ class AutoCategorizeRepository {
   /// Log a user correction (changed category on a transaction).
   Future<void> insertCorrection(CategorizationCorrectionsCompanion correction) {
     return _db.into(_db.categorizationCorrections).insert(correction);
+  }
+
+  /// Count corrections matching a `(normalizePayee(payee), categoryId)` pair
+  /// within the last [days] days.
+  ///
+  /// Pulls all recent rows via SQL (filtered by `createdAt > cutoff` and
+  /// `newCategoryId`) and applies normalization in Dart, since the stored
+  /// `payee` is raw (not normalized) and normalization uses regex logic
+  /// SQLite can't express. Acceptable scale: ~1k rows per 90-day window.
+  Future<int> countRecentCorrectionsForPayee({
+    required String payeeNormalized,
+    required String categoryId,
+    required String Function(String raw) normalizer,
+    int days = 90,
+  }) async {
+    final cutoff = DateTime.now()
+        .subtract(Duration(days: days))
+        .millisecondsSinceEpoch;
+    final rows = await (_db.select(_db.categorizationCorrections)
+          ..where((c) =>
+              c.createdAt.isBiggerThanValue(cutoff) &
+              c.newCategoryId.equals(categoryId)))
+        .get();
+    var count = 0;
+    for (final r in rows) {
+      if (normalizer(r.payee) == payeeNormalized) count++;
+    }
+    return count;
   }
 }

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -1,5 +1,7 @@
 import 'package:drift/drift.dart';
 
+import '../../domain/usecases/categorize/payee_normalization.dart'
+    as payee_norm;
 import '../local/database/app_database.dart';
 
 /// Repository for auto-categorization data: rules, payee cache, and corrections.
@@ -138,17 +140,17 @@ class AutoCategorizeRepository {
     return _db.into(_db.categorizationCorrections).insert(correction);
   }
 
-  /// Count corrections matching a `(normalizePayee(payee), categoryId)` pair
+  /// Count corrections matching `(normalizePayee(payee), categoryId)`
   /// within the last [days] days.
   ///
-  /// Pulls all recent rows via SQL (filtered by `createdAt > cutoff` and
-  /// `newCategoryId`) and applies normalization in Dart, since the stored
-  /// `payee` is raw (not normalized) and normalization uses regex logic
-  /// SQLite can't express. Acceptable scale: ~1k rows per 90-day window.
+  /// Caller passes an already-normalized payee. Internally we apply the
+  /// same normalization to each correction row's raw payee, since the
+  /// stored `payee` is raw and normalization uses regex logic SQLite
+  /// can't express. Acceptable scale: ~1k rows per 90-day window after
+  /// the SQL filter on `createdAt + newCategoryId`.
   Future<int> countRecentCorrectionsForPayee({
     required String payeeNormalized,
     required String categoryId,
-    required String Function(String raw) normalizer,
     int days = 90,
   }) async {
     final cutoff = DateTime.now()
@@ -161,7 +163,7 @@ class AutoCategorizeRepository {
         .get();
     var count = 0;
     for (final r in rows) {
-      if (normalizer(r.payee) == payeeNormalized) count++;
+      if (payee_norm.normalizePayee(r.payee) == payeeNormalized) count++;
     }
     return count;
   }

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -90,6 +90,27 @@ class AutoCategorizeRepository {
     });
   }
 
+  /// Retarget multiple rules' categoryId in a single batched transaction.
+  /// Used by RuleSeeder's one-shot retargets so a mid-loop failure can't
+  /// leave the table partially updated.
+  Future<void> updateRulesCategoryBatch(
+    Map<String, String> ruleIdToCategoryId,
+    int updatedAt,
+  ) {
+    return _db.batch((batch) {
+      for (final entry in ruleIdToCategoryId.entries) {
+        batch.update(
+          _db.autoCategorizeRules,
+          AutoCategorizeRulesCompanion(
+            categoryId: Value(entry.value),
+            updatedAt: Value(updatedAt),
+          ),
+          where: (r) => r.id.equals(entry.key),
+        );
+      }
+    });
+  }
+
   /// Check if any rules exist.
   Future<bool> hasRules() async {
     final count = _db.autoCategorizeRules.id.count();

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -7,6 +7,7 @@ import '../../../data/local/database/app_database.dart';
 import '../../../data/repositories/account_repository.dart';
 import '../../../data/repositories/auto_categorize_repository.dart';
 import '../../../data/repositories/transaction_repository.dart';
+import 'payee_normalization.dart' as payee_norm;
 
 /// Service for automatic transaction categorization.
 ///
@@ -24,84 +25,16 @@ class AutoCategorizeService {
 
   static const _confidenceThreshold = 0.8;
 
-  /// Known POS terminal prefixes to strip from payee names.
-  static final _posPrefixes = [
-    'SQ *',
-    'TST* ',
-    'TST*',
-    'PAYPAL *',
-    'SP * ',
-    'SP *',
-    'CKE*',
-    'DD *',
-    'GOOGLE *',
-    'APL*',
-  ];
-
-  /// Patterns that should be replaced entirely with a canonical name.
-  static final _canonicalReplacements = [
-    (RegExp(r'^AMZN MKTP US\b.*', caseSensitive: false), 'AMAZON'),
-    (RegExp(r'^AMAZON\.COM\b.*', caseSensitive: false), 'AMAZON'),
-    (RegExp(r'^AMZN\b.*', caseSensitive: false), 'AMAZON'),
-  ];
-
-  /// Trailing noise patterns to strip.
-  static final _trailingNoise = RegExp(
-    r'\s*#\d+$'        // trailing reference numbers
-    r'|\s+[A-Z]{2}\s+\d{5}(-\d{4})?$'  // state + zip
-    r'|\s+\d{3}-\d{3}-\d{4}$'          // phone numbers
-  );
-
-  /// Trailing store/location identifiers.
-  static final _trailingStoreId = RegExp(
-    r'\s+(S\d+|ST\d+|T\d+|STORE\s*\d+|LOC\s*\d+|UNIT\s*\d+)$',
-  );
-
-  /// Trailing transaction/reference IDs (6+ chars, must contain both letters
-  /// and digits to avoid stripping real words like SUPERCENTER).
-  static final _trailingRefId = RegExp(r'\s+(?=[A-Z0-9]*[0-9])(?=[A-Z0-9]*[A-Z])[A-Z0-9]{6,}$');
-
-  /// Trailing date-like patterns (MM/DD).
-  static final _trailingDate = RegExp(r'\s+\d{2}/\d{2}$');
-
   // ---------------------------------------------------------------------------
   // Payee normalization
   // ---------------------------------------------------------------------------
 
   /// Normalize a raw payee string for consistent matching.
-  String normalizePayee(String raw) {
-    var s = raw.trim().toUpperCase();
-
-    // Replace canonical patterns first (e.g., AMZN MKTP US* → AMAZON)
-    for (final (pattern, replacement) in _canonicalReplacements) {
-      if (pattern.hasMatch(s)) return replacement;
-    }
-
-    // Strip POS prefixes
-    for (final prefix in _posPrefixes) {
-      if (s.startsWith(prefix.toUpperCase())) {
-        s = s.substring(prefix.length);
-        break;
-      }
-    }
-
-    // Strip trailing noise
-    s = s.replaceAll(_trailingNoise, '');
-
-    // Strip trailing date-like patterns first (exposes store/ref IDs)
-    s = s.replaceAll(_trailingDate, '');
-
-    // Strip trailing store/location identifiers
-    s = s.replaceAll(_trailingStoreId, '');
-
-    // Strip trailing transaction/reference IDs
-    s = s.replaceAll(_trailingRefId, '');
-
-    // Collapse whitespace
-    s = s.replaceAll(RegExp(r'\s+'), ' ').trim();
-
-    return s;
-  }
+  ///
+  /// Delegates to the top-level `normalizePayee` in `payee_normalization.dart`
+  /// so the same logic is reachable from contexts without an
+  /// `AutoCategorizeService` instance (e.g. `RuleSuggestionService`).
+  String normalizePayee(String raw) => payee_norm.normalizePayee(raw);
 
   // ---------------------------------------------------------------------------
   // Similarity matching

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -302,6 +302,9 @@ class AutoCategorizeService {
       // Side effect: the categoryId on the saved transaction (user's literal
       // choice) and the cached categoryId (learned winner) can diverge. That
       // is intentional — the cache only influences *future* matches.
+      assert(existing.useCount >= 1,
+          'PayeeCategoryCache.useCount must be >= 1 per schema default; '
+          'got ${existing.useCount}');
       final penalized = existing.useCount - 1;
       if (penalized >= 1) {
         final newConfidence = min(1.0, 0.5 + (penalized * 0.1));

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -9,6 +9,34 @@ import '../../../data/repositories/auto_categorize_repository.dart';
 import '../../../data/repositories/transaction_repository.dart';
 import 'payee_normalization.dart' as payee_norm;
 
+/// Where a categorize() decision came from.
+enum CategorizationSource { none, cache, rule }
+
+/// Result of a traced categorization. Mirrors the `categoryId` returned by
+/// the existing [AutoCategorizeService.categorize] but adds provenance for
+/// debugging and future "why was this categorized?" UI.
+class CategorizationTrace {
+  const CategorizationTrace({
+    this.categoryId,
+    required this.normalizedPayee,
+    required this.source,
+    this.cacheConfidence,
+    this.matchedRule,
+  });
+
+  final String? categoryId;
+  final String normalizedPayee;
+  final CategorizationSource source;
+
+  /// Populated whenever a cache row exists for the payee, even if its
+  /// confidence was below the auto-apply threshold. Useful for "we have a
+  /// guess but didn't auto-apply" UI hints.
+  final double? cacheConfidence;
+
+  /// Populated when [source] is `CategorizationSource.rule`.
+  final AutoCategorizeRule? matchedRule;
+}
+
 /// Service for automatic transaction categorization.
 ///
 /// Two-tier pipeline:
@@ -101,26 +129,67 @@ class AutoCategorizeService {
     String? accountId,
     String? accountType,
   }) async {
-    final normalized = normalizePayee(payee);
-    if (normalized.isEmpty) return null;
+    final trace = await categorizeWithTrace(
+      payee,
+      amountCents: amountCents,
+      accountId: accountId,
+      accountType: accountType,
+    );
+    return trace.categoryId;
+  }
 
-    // Tier 1: Payee cache lookup (partitioned by account bucket)
+  /// Categorize with a detailed trace of which tier (cache vs. rule) matched.
+  ///
+  /// Used by the Settings → Auto-Categorization Rules "Test a payee" panel
+  /// for debugging and by future "why was this transaction categorized?"
+  /// UX. Mirrors [categorize] but returns full provenance instead of just
+  /// the categoryId.
+  Future<CategorizationTrace> categorizeWithTrace(
+    String payee, {
+    int? amountCents,
+    String? accountId,
+    String? accountType,
+  }) async {
+    final normalized = normalizePayee(payee);
+    if (normalized.isEmpty) {
+      return const CategorizationTrace(
+        normalizedPayee: '',
+        source: CategorizationSource.none,
+      );
+    }
+
     final bucket = cacheBucket(accountType);
     final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
-      return cacheEntry.categoryId;
+      return CategorizationTrace(
+        categoryId: cacheEntry.categoryId,
+        normalizedPayee: normalized,
+        source: CategorizationSource.cache,
+        cacheConfidence: cacheEntry.confidence,
+      );
     }
 
-    // Tier 2: Rules engine
     final rules = await _autoCatRepo.getEnabledRules();
     for (final rule in rules) {
       if (_ruleMatches(rule, normalized, amountCents, accountId,
           accountType: accountType)) {
-        return rule.categoryId;
+        return CategorizationTrace(
+          categoryId: rule.categoryId,
+          normalizedPayee: normalized,
+          source: CategorizationSource.rule,
+          matchedRule: rule,
+          // Include any sub-threshold cache hint so the UI can show
+          // "we have a guess but didn't auto-apply".
+          cacheConfidence: cacheEntry?.confidence,
+        );
       }
     }
 
-    return null;
+    return CategorizationTrace(
+      normalizedPayee: normalized,
+      source: CategorizationSource.none,
+      cacheConfidence: cacheEntry?.confidence,
+    );
   }
 
   /// Check if a rule matches the given transaction attributes.
@@ -190,25 +259,62 @@ class AutoCategorizeService {
     String? accountId,
     String? accountType,
   }) async {
-    final normalized = normalizePayee(payee);
-    if (normalized.isEmpty) return null;
+    final trace = await categorizeWithPreloadedRulesAndTrace(
+      payee,
+      rules,
+      amountCents: amountCents,
+      accountId: accountId,
+      accountType: accountType,
+    );
+    return trace.categoryId;
+  }
 
-    // Tier 1: Payee cache lookup (partitioned by account bucket)
+  /// Trace variant of [categorizeWithPreloadedRules]. See
+  /// [categorizeWithTrace] for the rationale.
+  Future<CategorizationTrace> categorizeWithPreloadedRulesAndTrace(
+    String payee,
+    List<AutoCategorizeRule> rules, {
+    int? amountCents,
+    String? accountId,
+    String? accountType,
+  }) async {
+    final normalized = normalizePayee(payee);
+    if (normalized.isEmpty) {
+      return const CategorizationTrace(
+        normalizedPayee: '',
+        source: CategorizationSource.none,
+      );
+    }
+
     final bucket = cacheBucket(accountType);
     final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
-      return cacheEntry.categoryId;
+      return CategorizationTrace(
+        categoryId: cacheEntry.categoryId,
+        normalizedPayee: normalized,
+        source: CategorizationSource.cache,
+        cacheConfidence: cacheEntry.confidence,
+      );
     }
 
-    // Tier 2: Match against pre-loaded rules
     for (final rule in rules) {
       if (_ruleMatches(rule, normalized, amountCents, accountId,
           accountType: accountType)) {
-        return rule.categoryId;
+        return CategorizationTrace(
+          categoryId: rule.categoryId,
+          normalizedPayee: normalized,
+          source: CategorizationSource.rule,
+          matchedRule: rule,
+          cacheConfidence: cacheEntry?.confidence,
+        );
       }
     }
 
-    return null;
+    return CategorizationTrace(
+      normalizedPayee: normalized,
+      source: CategorizationSource.none,
+      cacheConfidence: cacheEntry?.confidence,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -25,6 +25,29 @@ class AutoCategorizeService {
 
   static const _confidenceThreshold = 0.8;
 
+  /// Account types whose payee semantics differ from everyday spending —
+  /// dividends, transfers in/out, fees. Categorizing STARBUCKS as Coffee in
+  /// a checking account must not bleed into a brokerage account where the
+  /// same payee likely represents a fee or distribution.
+  static const _investmentAccountTypes = {
+    'brokerage',
+    '401k',
+    'ira',
+    'roth_ira',
+    'hsa',
+    'crypto',
+  };
+
+  /// Cache partition key. Two buckets: 'standard' vs 'investment'.
+  /// Investment-vs-not is the only axis where payee semantics actually flip;
+  /// finer-grained partitioning (per accountType) would starve every bucket.
+  static String cacheBucket(String? accountType) {
+    if (accountType == null) return 'standard';
+    return _investmentAccountTypes.contains(accountType)
+        ? 'investment'
+        : 'standard';
+  }
+
   // ---------------------------------------------------------------------------
   // Payee normalization
   // ---------------------------------------------------------------------------
@@ -81,8 +104,9 @@ class AutoCategorizeService {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return null;
 
-    // Tier 1: Payee cache lookup
-    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized);
+    // Tier 1: Payee cache lookup (partitioned by account bucket)
+    final bucket = cacheBucket(accountType);
+    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
       return cacheEntry.categoryId;
     }
@@ -169,8 +193,9 @@ class AutoCategorizeService {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return null;
 
-    // Tier 1: Payee cache lookup (still per-transaction)
-    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized);
+    // Tier 1: Payee cache lookup (partitioned by account bucket)
+    final bucket = cacheBucket(accountType);
+    final cacheEntry = await _autoCatRepo.getCacheEntry(normalized, bucket);
     if (cacheEntry != null && cacheEntry.confidence >= _confidenceThreshold) {
       return cacheEntry.categoryId;
     }
@@ -191,22 +216,29 @@ class AutoCategorizeService {
   // ---------------------------------------------------------------------------
 
   /// Record a user's category assignment to update the payee cache.
+  ///
+  /// [accountType] (optional) determines the cache bucket so investment-account
+  /// learning doesn't bleed into standard-account categorization, and vice
+  /// versa. Null defaults to 'standard'.
   Future<void> recordCategoryAssignment({
     required String payee,
     required String categoryId,
     String? transactionId,
     String? oldCategoryId,
+    String? accountType,
   }) async {
     final normalized = normalizePayee(payee);
     if (normalized.isEmpty) return;
 
     final now = DateTime.now().millisecondsSinceEpoch;
-    final existing = await _autoCatRepo.getCacheEntry(normalized);
+    final bucket = cacheBucket(accountType);
+    final existing = await _autoCatRepo.getCacheEntry(normalized, bucket);
 
     if (existing == null) {
-      // First time seeing this payee
+      // First time seeing this payee in this bucket
       await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
         payeeNormalized: Value(normalized),
+        accountBucket: Value(bucket),
         categoryId: Value(categoryId),
         confidence: const Value(0.5),
         source: const Value('user'),
@@ -219,6 +251,7 @@ class AutoCategorizeService {
       final newConfidence = min(1.0, 0.5 + (newCount * 0.1));
       await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
         payeeNormalized: Value(normalized),
+        accountBucket: Value(bucket),
         categoryId: Value(categoryId),
         confidence: Value(newConfidence),
         source: const Value('user'),
@@ -243,6 +276,7 @@ class AutoCategorizeService {
         final newConfidence = min(1.0, 0.5 + (penalized * 0.1));
         await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
           payeeNormalized: Value(normalized),
+          accountBucket: Value(bucket),
           categoryId: Value(existing.categoryId),
           confidence: Value(newConfidence),
           source: const Value('user'),
@@ -253,6 +287,7 @@ class AutoCategorizeService {
         // useCount was 1; nothing left to keep — adopt the new category.
         await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
           payeeNormalized: Value(normalized),
+          accountBucket: Value(bucket),
           categoryId: Value(categoryId),
           confidence: const Value(0.5),
           source: const Value('user'),

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -293,15 +293,37 @@ class AutoCategorizeService {
         updatedAt: Value(now),
       ));
     } else {
-      // Different category — user is correcting; reset
-      await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
-        payeeNormalized: Value(normalized),
-        categoryId: Value(categoryId),
-        confidence: const Value(0.5),
-        source: const Value('user'),
-        useCount: const Value(1),
-        updatedAt: Value(now),
-      ));
+      // Different category — penalize one step, do NOT wipe. A useCount of N
+      // requires N corrections to flip. A single misclick demotes the entry
+      // by 1; the previously-learned category is preserved unless its weight
+      // falls to zero. This protects the minimum-threshold (useCount=3)
+      // entry from being wiped by a single fat-finger.
+      //
+      // Side effect: the categoryId on the saved transaction (user's literal
+      // choice) and the cached categoryId (learned winner) can diverge. That
+      // is intentional — the cache only influences *future* matches.
+      final penalized = existing.useCount - 1;
+      if (penalized >= 1) {
+        final newConfidence = min(1.0, 0.5 + (penalized * 0.1));
+        await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
+          payeeNormalized: Value(normalized),
+          categoryId: Value(existing.categoryId),
+          confidence: Value(newConfidence),
+          source: const Value('user'),
+          useCount: Value(penalized),
+          updatedAt: Value(now),
+        ));
+      } else {
+        // useCount was 1; nothing left to keep — adopt the new category.
+        await _autoCatRepo.upsertCacheEntry(PayeeCategoryCacheCompanion(
+          payeeNormalized: Value(normalized),
+          categoryId: Value(categoryId),
+          confidence: const Value(0.5),
+          source: const Value('user'),
+          useCount: const Value(1),
+          updatedAt: Value(now),
+        ));
+      }
     }
 
     // Log correction if the category actually changed

--- a/lib/domain/usecases/categorize/default_rules_data.dart
+++ b/lib/domain/usecases/categorize/default_rules_data.dart
@@ -127,7 +127,8 @@ const defaultMerchantMappings = <(String, String)>[
   ('QUIKTRIP', 'Gas'),
   ('PILOT', 'Gas'),
   ('FLYING J', 'Gas'),
-  ('LOVE', 'Gas'),
+  ('LOVES TRAVEL', 'Gas'),
+  ("LOVE'S TRAVEL", 'Gas'),
   ('VALERO', 'Gas'),
   ('CITGO', 'Gas'),
   ('PHILLIPS 66', 'Gas'),
@@ -158,20 +159,20 @@ const defaultMerchantMappings = <(String, String)>[
   // -------------------------------------------------------------------------
   // Transportation → Auto Maintenance
   // -------------------------------------------------------------------------
-  ('JIFFY LUBE', 'Transportation'),
-  ('VALVOLINE', 'Transportation'),
-  ('FIRESTONE', 'Transportation'),
-  ('AUTOZONE', 'Transportation'),
-  ('PEP BOYS', 'Transportation'),
-  ("O'REILLY", 'Transportation'),
-  ('ADVANCE AUTO', 'Transportation'),
-  ('NAPA AUTO', 'Transportation'),
-  ('MIDAS', 'Transportation'),
-  ('GOODYEAR', 'Transportation'),
-  ('DISCOUNT TIRE', 'Transportation'),
-  ('MAACO', 'Transportation'),
-  ('MEINEKE', 'Transportation'),
-  ('SAFELITE', 'Transportation'),
+  ('JIFFY LUBE', 'Auto Maintenance'),
+  ('VALVOLINE', 'Auto Maintenance'),
+  ('FIRESTONE', 'Auto Maintenance'),
+  ('AUTOZONE', 'Auto Maintenance'),
+  ('PEP BOYS', 'Auto Maintenance'),
+  ("O'REILLY", 'Auto Maintenance'),
+  ('ADVANCE AUTO', 'Auto Maintenance'),
+  ('NAPA AUTO', 'Auto Maintenance'),
+  ('MIDAS', 'Auto Maintenance'),
+  ('GOODYEAR', 'Auto Maintenance'),
+  ('DISCOUNT TIRE', 'Auto Maintenance'),
+  ('MAACO', 'Auto Maintenance'),
+  ('MEINEKE', 'Auto Maintenance'),
+  ('SAFELITE', 'Auto Maintenance'),
 
   // -------------------------------------------------------------------------
   // Entertainment → Subscriptions
@@ -414,6 +415,79 @@ const defaultMerchantMappings = <(String, String)>[
   ('LIBERTY MUTUAL', 'Insurance'),
   ('NATIONWIDE', 'Insurance'),
   ('FARMERS INS', 'Insurance'),
+
+  // -------------------------------------------------------------------------
+  // 2025-era additions (curated; see plan for excluded entries)
+  // -------------------------------------------------------------------------
+
+  // EV charging → Gas
+  ('TESLA SUPERCHARGER', 'Gas'),
+  ('TESLA CHARGING', 'Gas'),
+  ('ELECTRIFY AMERICA', 'Gas'),
+  ('EVGO', 'Gas'),
+  ('CHARGEPOINT', 'Gas'),
+  ('BLINK CHARGING', 'Gas'),
+
+  // Telehealth → Medical
+  ('TELADOC', 'Medical'),
+  ('BETTERHELP', 'Medical'),
+  ('TALKSPACE', 'Medical'),
+  ('HIMS', 'Medical'),
+  ('HERS', 'Medical'),
+  ('RO HEALTH', 'Medical'),
+
+  // Modern Subscriptions
+  ('SUBSTACK', 'Subscriptions'),
+  ('PATREON', 'Subscriptions'),
+  ('MAX.COM', 'Subscriptions'),
+  ('HBO MAX', 'Subscriptions'),
+  ('GITHUB', 'Subscriptions'),
+  ('CHATGPT', 'Subscriptions'),
+  ('ANTHROPIC', 'Subscriptions'),
+  ('CLAUDE.AI', 'Subscriptions'),
+  ('PERPLEXITY', 'Subscriptions'),
+  ('1PASSWORD', 'Subscriptions'),
+  ('LASTPASS', 'Subscriptions'),
+  ('PROTON', 'Subscriptions'),
+  ('NORDVPN', 'Subscriptions'),
+  ('EXPRESSVPN', 'Subscriptions'),
+
+  // Public Transit (micromobility)
+  ('LIME', 'Public Transit'),
+  ('BIRD RIDES', 'Public Transit'), // bare 'BIRD' too generic
+  ('CITI BIKE', 'Public Transit'),
+  ('REVEL', 'Public Transit'),
+
+  // Groceries — specific warehouse strings (bare 'COSTCO' would match COSTCO GAS)
+  ('COSTCO WHSE', 'Groceries'),
+  ('COSTCO WHOLESALE', 'Groceries'),
+  ("SAM'S CLUB", 'Groceries'),
+  ('SAMS CLUB', 'Groceries'),
+  ('GOPUFF', 'Groceries'),
+  ('THRIVE MARKET', 'Groceries'),
+  ('MISFITS MARKET', 'Groceries'),
+  ('IMPERFECT FOODS', 'Groceries'),
+
+  // Delivery
+  ('CAVIAR', 'Delivery'),
+  ('CHOWNOW', 'Delivery'),
+
+  // Clothing
+  ('SHEIN', 'Clothing'),
+  ('ZAPPOS', 'Clothing'),
+  ('REI CO-OP', 'Clothing'), // bare 'REI' too generic
+  ('PATAGONIA', 'Clothing'),
+
+  // Coffee Shops
+  ('BLACK ROCK COFFEE', 'Coffee Shops'),
+  ('BIGGBY', 'Coffee Shops'),
+
+  // Restaurants (modern chains)
+  ('SWEETGREEN', 'Restaurants'),
+  ('CAVA', 'Restaurants'),
+  ('SHAKE SHACK', 'Restaurants'),
+  ('MOD PIZZA', 'Restaurants'),
+  ('BLAZE PIZZA', 'Restaurants'),
 ];
 
 /// Investment account transaction rules (matched by account type).

--- a/lib/domain/usecases/categorize/payee_normalization.dart
+++ b/lib/domain/usecases/categorize/payee_normalization.dart
@@ -1,0 +1,84 @@
+/// Payee-name normalization for consistent matching across the
+/// auto-categorization system.
+///
+/// Extracted as a top-level function so it can be used from contexts
+/// that don't have an `AutoCategorizeService` instance — e.g. the
+/// suggested-rule prompt logic in the transaction edit screen and (in
+/// Phase 3) the `RuleSuggestionService`.
+library;
+
+/// Known POS terminal prefixes to strip from payee names.
+final _posPrefixes = [
+  'SQ *',
+  'TST* ',
+  'TST*',
+  'PAYPAL *',
+  'SP * ',
+  'SP *',
+  'CKE*',
+  'DD *',
+  'GOOGLE *',
+  'APL*',
+];
+
+/// Patterns that should be replaced entirely with a canonical name.
+final _canonicalReplacements = [
+  (RegExp(r'^AMZN MKTP US\b.*', caseSensitive: false), 'AMAZON'),
+  (RegExp(r'^AMAZON\.COM\b.*', caseSensitive: false), 'AMAZON'),
+  (RegExp(r'^AMZN\b.*', caseSensitive: false), 'AMAZON'),
+];
+
+/// Trailing noise patterns to strip.
+final _trailingNoise = RegExp(
+  r'\s*#\d+$' // trailing reference numbers
+  r'|\s+[A-Z]{2}\s+\d{5}(-\d{4})?$' // state + zip
+  r'|\s+\d{3}-\d{3}-\d{4}$', // phone numbers
+);
+
+/// Trailing store/location identifiers.
+final _trailingStoreId = RegExp(
+  r'\s+(S\d+|ST\d+|T\d+|STORE\s*\d+|LOC\s*\d+|UNIT\s*\d+)$',
+);
+
+/// Trailing transaction/reference IDs (6+ chars, must contain both letters
+/// and digits to avoid stripping real words like SUPERCENTER).
+final _trailingRefId =
+    RegExp(r'\s+(?=[A-Z0-9]*[0-9])(?=[A-Z0-9]*[A-Z])[A-Z0-9]{6,}$');
+
+/// Trailing date-like patterns (MM/DD).
+final _trailingDate = RegExp(r'\s+\d{2}/\d{2}$');
+
+/// Normalize a raw payee string for consistent matching.
+///
+/// Steps (order matters):
+/// 1. Trim + uppercase
+/// 2. Canonical replacement (e.g. AMZN MKTP US → AMAZON)
+/// 3. POS prefix stripping (SQ *, TST*, PAYPAL *, ...)
+/// 4. Trailing noise stripping (state+zip, phone, ref#)
+/// 5. Trailing date stripping (exposes store/ref IDs underneath)
+/// 6. Trailing store-ID stripping (S123, ST456, LOC 2)
+/// 7. Trailing transaction-ID stripping (6+ alphanumeric, mixed)
+/// 8. Whitespace collapse
+String normalizePayee(String raw) {
+  var s = raw.trim().toUpperCase();
+
+  for (final (pattern, replacement) in _canonicalReplacements) {
+    if (pattern.hasMatch(s)) return replacement;
+  }
+
+  for (final prefix in _posPrefixes) {
+    if (s.startsWith(prefix.toUpperCase())) {
+      s = s.substring(prefix.length);
+      break;
+    }
+  }
+
+  s = s.replaceAll(_trailingNoise, '');
+  s = s.replaceAll(_trailingDate, '');
+  s = s.replaceAll(_trailingStoreId, '');
+  s = s.replaceAll(_trailingRefId, '');
+
+  s = s.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+  return s;
+}

--- a/lib/domain/usecases/categorize/rule_conflicts.dart
+++ b/lib/domain/usecases/categorize/rule_conflicts.dart
@@ -1,0 +1,97 @@
+import '../../../data/local/database/app_database.dart';
+
+/// Kinds of conflicts that can arise when creating/editing an auto-categorize
+/// rule. All conflicts are warnings — save is never blocked.
+enum RuleConflictKind {
+  /// Another rule has the same effective payee pattern but maps to a
+  /// different category. Whichever has lower priority wins, which can
+  /// surprise the user.
+  samePatternDifferentCategory,
+
+  /// This rule's match set covers another rule's match set, and this rule
+  /// has equal-or-higher priority. The other rule would never run.
+  shadowsOther,
+
+  /// Another rule's match set covers this rule's match set, and the other
+  /// rule has equal-or-higher priority. This rule would never run.
+  shadowedByOther,
+}
+
+class RuleConflict {
+  const RuleConflict({required this.kind, required this.other});
+  final RuleConflictKind kind;
+  final AutoCategorizeRule other;
+}
+
+/// Detect conflicts between a proposed rule and the set of existing rules.
+///
+/// Only payee-pattern conflicts are detected. Rules with both `payeeExact`
+/// and `payeeContains` null (amount-range or account-type only) are skipped
+/// — checking those would require modeling the full match space and isn't
+/// worth the complexity for a warning-only UI affordance.
+///
+/// `editingRuleId` is the id of the rule being edited (so self-conflicts
+/// are filtered out); null when creating a new rule.
+List<RuleConflict> detectRuleConflicts({
+  required String? editingRuleId,
+  required String? payeeContains,
+  required String? payeeExact,
+  required String? categoryId,
+  required int priority,
+  required List<AutoCategorizeRule> existingRules,
+}) {
+  final rPc = (payeeContains == null || payeeContains.isEmpty)
+      ? null
+      : payeeContains.toUpperCase();
+  final rPe = (payeeExact == null || payeeExact.isEmpty)
+      ? null
+      : payeeExact.toUpperCase();
+  final rEffective = rPe ?? rPc;
+  if (rEffective == null || categoryId == null) return const [];
+
+  final conflicts = <RuleConflict>[];
+
+  for (final q in existingRules) {
+    if (q.id == editingRuleId) continue;
+    final qPc = q.payeeContains?.toUpperCase();
+    final qPe = q.payeeExact?.toUpperCase();
+    final qEffective = qPe ?? qPc;
+    if (qEffective == null) continue;
+
+    if (qEffective == rEffective && q.categoryId != categoryId) {
+      conflicts.add(
+        RuleConflict(kind: RuleConflictKind.samePatternDifferentCategory, other: q),
+      );
+      continue;
+    }
+
+    if (priority <= q.priority && _aShadowsB(rPc, rPe, qPc, qPe)) {
+      conflicts.add(RuleConflict(kind: RuleConflictKind.shadowsOther, other: q));
+      continue;
+    }
+
+    if (priority >= q.priority && _aShadowsB(qPc, qPe, rPc, rPe)) {
+      conflicts.add(
+        RuleConflict(kind: RuleConflictKind.shadowedByOther, other: q),
+      );
+      continue;
+    }
+  }
+
+  return conflicts;
+}
+
+/// Whether rule A's match set strictly contains rule B's match set.
+///
+/// Case combos:
+///   A exact, B exact      → never strict superset (only equal at most)
+///   A contains, B contains→ A⊃B iff B's pattern strictly contains A's pattern
+///   A contains, B exact   → A⊃B iff B's exact string strictly contains A's contains pattern
+///   A exact, B contains   → A⊃B never (B's set is unbounded)
+bool _aShadowsB(String? aPc, String? aPe, String? bPc, String? bPe) {
+  if (aPe != null) return false;
+  if (aPc == null) return false;
+  final bStr = bPe ?? bPc;
+  if (bStr == null) return false;
+  return bStr != aPc && bStr.contains(aPc);
+}

--- a/lib/domain/usecases/categorize/rule_conflicts.dart
+++ b/lib/domain/usecases/categorize/rule_conflicts.dart
@@ -40,12 +40,17 @@ List<RuleConflict> detectRuleConflicts({
   required int priority,
   required List<AutoCategorizeRule> existingRules,
 }) {
-  final rPc = (payeeContains == null || payeeContains.isEmpty)
+  // Trim first so whitespace-only patterns are treated as empty (otherwise
+  // '   '.toUpperCase() becomes a literal three-space pattern and matches
+  // weird things).
+  final pcTrimmed = payeeContains?.trim();
+  final peTrimmed = payeeExact?.trim();
+  final rPc = (pcTrimmed == null || pcTrimmed.isEmpty)
       ? null
-      : payeeContains.toUpperCase();
-  final rPe = (payeeExact == null || payeeExact.isEmpty)
+      : pcTrimmed.toUpperCase();
+  final rPe = (peTrimmed == null || peTrimmed.isEmpty)
       ? null
-      : payeeExact.toUpperCase();
+      : peTrimmed.toUpperCase();
   final rEffective = rPe ?? rPc;
   if (rEffective == null || categoryId == null) return const [];
 

--- a/lib/domain/usecases/categorize/rule_seeder.dart
+++ b/lib/domain/usecases/categorize/rule_seeder.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../data/local/database/app_database.dart';
@@ -99,7 +100,10 @@ class RuleSeeder {
   /// grows, the next startup inserts only the new entries. User-created rules
   /// with identical payeeContains are respected (skipped).
   Future<bool> _backfillMissingDefaultRules() async {
-    final existingRules = await _autoCatRepo.getEnabledRules();
+    // Use getAllRules (not getEnabledRules) so user-disabled rules also
+    // dedupe — otherwise re-seeding would insert duplicates next to the
+    // user's disabled rows.
+    final existingRules = await _autoCatRepo.getAllRules();
 
     String key(String payeeContains, String? accountType) =>
         '${payeeContains.toUpperCase()}|${accountType ?? ''}';
@@ -132,10 +136,14 @@ class RuleSeeder {
     final now = DateTime.now().millisecondsSinceEpoch;
     var priority = existingRules.length;
     final rules = <AutoCategorizeRulesCompanion>[];
+    final skipped = <String>[];
 
     for (final (payeeContains, categoryName) in missingGeneral) {
       final categoryId = catByName[categoryName];
-      if (categoryId == null) continue;
+      if (categoryId == null) {
+        skipped.add('$payeeContains → $categoryName');
+        continue;
+      }
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName',
@@ -150,7 +158,10 @@ class RuleSeeder {
 
     for (final (payeeContains, categoryName, accountType) in missingInvestment) {
       final categoryId = catByName[categoryName];
-      if (categoryId == null) continue;
+      if (categoryId == null) {
+        skipped.add('$payeeContains → $categoryName ($accountType)');
+        continue;
+      }
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName ($accountType)',
@@ -162,6 +173,14 @@ class RuleSeeder {
         createdAt: now,
         updatedAt: now,
       ));
+    }
+
+    if (kDebugMode && skipped.isNotEmpty) {
+      debugPrint(
+        'RuleSeeder: skipped ${skipped.length} default rule(s) — '
+        'target category not seeded: ${skipped.take(5).join(', ')}'
+        '${skipped.length > 5 ? ' …' : ''}',
+      );
     }
 
     if (rules.isEmpty) return false;
@@ -194,12 +213,19 @@ class RuleSeeder {
       }
     }
     if (transportationParentId == null || autoMaintenanceId == null) {
+      if (kDebugMode && transportationParentId != null) {
+        debugPrint(
+          'RuleSeeder: Auto Maintenance subcategory not yet seeded; '
+          'retarget skipped this launch',
+        );
+      }
       return false;
     }
 
-    final rules = await _autoCatRepo.getEnabledRules();
-    final now = DateTime.now().millisecondsSinceEpoch;
-    var retargetCount = 0;
+    // Use getAllRules so user-disabled rules also get retargeted — if they
+    // re-enable later they should map to the correct subcategory.
+    final rules = await _autoCatRepo.getAllRules();
+    final retargets = <String, String>{};
     for (final r in rules) {
       if (r.payeeContains == null) continue;
       if (!autoMaintenancePayees.contains(r.payeeContains!.toUpperCase())) {
@@ -207,17 +233,16 @@ class RuleSeeder {
       }
       if (r.categoryId != transportationParentId) continue;
       if (r.updatedAt != r.createdAt) continue; // user-edited; leave alone
-
-      await _autoCatRepo.updateRule(
-        AutoCategorizeRulesCompanion(
-          id: Value(r.id),
-          categoryId: Value(autoMaintenanceId),
-          updatedAt: Value(now),
-        ),
-      );
-      retargetCount++;
+      retargets[r.id] = autoMaintenanceId;
     }
 
-    return retargetCount > 0;
+    if (retargets.isEmpty) return false;
+
+    // Batch the updates so a mid-loop failure can't leave partial state.
+    await _autoCatRepo.updateRulesCategoryBatch(
+      retargets,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    return true;
   }
 }

--- a/lib/domain/usecases/categorize/rule_seeder.dart
+++ b/lib/domain/usecases/categorize/rule_seeder.dart
@@ -24,7 +24,9 @@ class RuleSeeder {
   /// Returns true if rules were seeded.
   Future<bool> seedIfEmpty() async {
     if (await _autoCatRepo.hasRules()) {
-      return _backfillInvestmentRules();
+      final backfilled = await _backfillMissingDefaultRules();
+      final retargeted = await _retargetAutoMaintenanceRules();
+      return backfilled || retargeted;
     }
 
     final categories = await _categoryRepo.getAllCategories();
@@ -89,31 +91,41 @@ class RuleSeeder {
     return true;
   }
 
-  /// Backfill missing investment rules for existing users.
+  /// Backfill any default rules missing for existing users — both the
+  /// general merchant rules and the investment-scoped rules.
   ///
-  /// Uses set-based dedup: builds a set of existing (payeeContains, accountType)
-  /// combos and only inserts rules that don't already exist. This is
-  /// self-healing — any time investmentMerchantMappings grows, the next
-  /// startup backfills only the missing entries.
-  Future<bool> _backfillInvestmentRules() async {
+  /// Uses set-based dedup on `(payeeContains|accountType)` signatures so it's
+  /// self-healing: any time defaultMerchantMappings or investmentMerchantMappings
+  /// grows, the next startup inserts only the new entries. User-created rules
+  /// with identical payeeContains are respected (skipped).
+  Future<bool> _backfillMissingDefaultRules() async {
     final existingRules = await _autoCatRepo.getEnabledRules();
 
-    // Build set of existing investment rule signatures
-    final existingKeys = <String>{};
-    for (final r in existingRules) {
-      if (r.accountType != null && r.payeeContains != null) {
-        existingKeys.add('${r.payeeContains!.toUpperCase()}|${r.accountType}');
-      }
-    }
+    String key(String payeeContains, String? accountType) =>
+        '${payeeContains.toUpperCase()}|${accountType ?? ''}';
 
-    // Check which mappings are missing before loading categories
-    final missing = investmentMerchantMappings.where((m) =>
-        !existingKeys.contains('${m.$1.toUpperCase()}|${m.$3}'));
-    if (missing.isEmpty) return false;
+    final existingKeys = <String>{
+      for (final r in existingRules)
+        if (r.payeeContains != null) key(r.payeeContains!, r.accountType),
+    };
+
+    final missingGeneral = [
+      for (final m in defaultMerchantMappings)
+        if (!existingKeys.contains(key(m.$1, null))) m,
+    ];
+    final missingInvestment = [
+      for (final m in investmentMerchantMappings)
+        if (!existingKeys.contains(key(m.$1, m.$3))) m,
+    ];
+
+    if (missingGeneral.isEmpty && missingInvestment.isEmpty) return false;
 
     final categories = await _categoryRepo.getAllCategories();
     final catByName = <String, String>{};
-    for (final c in categories) {
+    for (final c in categories.where((c) => c.parentId == null)) {
+      catByName.putIfAbsent(c.name, () => c.id);
+    }
+    for (final c in categories.where((c) => c.parentId != null)) {
       catByName.putIfAbsent(c.name, () => c.id);
     }
 
@@ -121,10 +133,24 @@ class RuleSeeder {
     var priority = existingRules.length;
     final rules = <AutoCategorizeRulesCompanion>[];
 
-    for (final (payeeContains, categoryName, accountType) in missing) {
+    for (final (payeeContains, categoryName) in missingGeneral) {
       final categoryId = catByName[categoryName];
       if (categoryId == null) continue;
+      rules.add(AutoCategorizeRulesCompanion.insert(
+        id: _uuid.v4(),
+        name: '$payeeContains → $categoryName',
+        priority: priority++,
+        categoryId: categoryId,
+        payeeContains: Value(payeeContains),
+        isEnabled: const Value(true),
+        createdAt: now,
+        updatedAt: now,
+      ));
+    }
 
+    for (final (payeeContains, categoryName, accountType) in missingInvestment) {
+      final categoryId = catByName[categoryName];
+      if (categoryId == null) continue;
       rules.add(AutoCategorizeRulesCompanion.insert(
         id: _uuid.v4(),
         name: '$payeeContains → $categoryName ($accountType)',
@@ -141,5 +167,57 @@ class RuleSeeder {
     if (rules.isEmpty) return false;
     await _autoCatRepo.insertRules(rules);
     return true;
+  }
+
+  /// Auto-maintenance rules originally pointed at the Transportation parent
+  /// category because the 'Auto Maintenance' subcategory didn't exist in the
+  /// seed yet. Now that it does, retarget any seeded rule that the user
+  /// hasn't touched (createdAt == updatedAt) to the new subcategory.
+  ///
+  /// Returns true if any rules were retargeted. Skipped if 'Auto Maintenance'
+  /// hasn't been seeded yet (CategorySeeder backfill should run first).
+  Future<bool> _retargetAutoMaintenanceRules() async {
+    const autoMaintenancePayees = {
+      'JIFFY LUBE', 'VALVOLINE', 'FIRESTONE', 'AUTOZONE', 'PEP BOYS',
+      "O'REILLY", 'ADVANCE AUTO', 'NAPA AUTO', 'MIDAS', 'GOODYEAR',
+      'DISCOUNT TIRE', 'MAACO', 'MEINEKE', 'SAFELITE',
+    };
+
+    final categories = await _categoryRepo.getAllCategories();
+    String? transportationParentId;
+    String? autoMaintenanceId;
+    for (final c in categories) {
+      if (c.parentId == null && c.name == 'Transportation') {
+        transportationParentId = c.id;
+      } else if (c.parentId != null && c.name == 'Auto Maintenance') {
+        autoMaintenanceId = c.id;
+      }
+    }
+    if (transportationParentId == null || autoMaintenanceId == null) {
+      return false;
+    }
+
+    final rules = await _autoCatRepo.getEnabledRules();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    var retargetCount = 0;
+    for (final r in rules) {
+      if (r.payeeContains == null) continue;
+      if (!autoMaintenancePayees.contains(r.payeeContains!.toUpperCase())) {
+        continue;
+      }
+      if (r.categoryId != transportationParentId) continue;
+      if (r.updatedAt != r.createdAt) continue; // user-edited; leave alone
+
+      await _autoCatRepo.updateRule(
+        AutoCategorizeRulesCompanion(
+          id: Value(r.id),
+          categoryId: Value(autoMaintenanceId),
+          updatedAt: Value(now),
+        ),
+      );
+      retargetCount++;
+    }
+
+    return retargetCount > 0;
   }
 }

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -40,18 +40,27 @@ class _AutoCategorizeRulesScreenState
       duration: Duration(seconds: 2),
     ));
     try {
+      // Snapshot the uncategorized total before running so we can
+      // differentiate "nothing to do" from "ran but nothing matched".
+      final pendingBefore = await ref
+          .read(transactionRepositoryProvider)
+          .getUncategorizedTransactions();
       final count =
           await ref.read(autoCategorizeServiceProvider).categorizeUncategorized();
       if (!mounted) return;
       invalidateFinancialData(ref);
       messenger.hideCurrentSnackBar();
-      messenger.showSnackBar(SnackBar(
-        content: Text(
-          count == 0
-              ? 'No uncategorized transactions matched any rule'
-              : 'Categorized $count transaction${count == 1 ? '' : 's'}',
-        ),
-      ));
+      final String message;
+      if (pendingBefore.isEmpty) {
+        message = 'Nothing to categorize — no uncategorized transactions';
+      } else if (count == 0) {
+        message = '${pendingBefore.length} uncategorized transaction'
+            '${pendingBefore.length == 1 ? '' : 's'} '
+            'didn\'t match any rule';
+      } else {
+        message = 'Categorized $count transaction${count == 1 ? '' : 's'}';
+      }
+      messenger.showSnackBar(SnackBar(content: Text(message)));
     } catch (e) {
       if (!mounted) return;
       messenger.hideCurrentSnackBar();

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -5,9 +5,11 @@ import 'package:uuid/uuid.dart';
 
 import '../../../core/di/providers.dart';
 import '../../../data/local/database/models.dart';
+import '../../../domain/usecases/categorize/auto_categorize_service.dart';
 import '../../../domain/usecases/categorize/rule_conflicts.dart';
 import '../../shared/utils/provider_invalidation.dart';
 import '../../shared/widgets/category_picker_sheet.dart';
+import '../accounts/accounts_providers.dart';
 import 'auto_categorize_providers.dart';
 
 /// Screen for managing auto-categorization rules.
@@ -144,6 +146,7 @@ class _AutoCategorizeRulesScreenState
 
           return Column(
             children: [
+              _TestPayeePanel(categoryNames: categoryNames),
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
                 child: TextField(
@@ -484,6 +487,219 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     }
 
     Navigator.pop(context);
+  }
+}
+
+class _TestPayeePanel extends ConsumerStatefulWidget {
+  const _TestPayeePanel({required this.categoryNames});
+
+  final Map<String, String> categoryNames;
+
+  @override
+  ConsumerState<_TestPayeePanel> createState() => _TestPayeePanelState();
+}
+
+class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
+  final _payeeController = TextEditingController();
+  final _amountController = TextEditingController();
+  String? _accountId;
+  CategorizationTrace? _result;
+  bool _running = false;
+
+  @override
+  void dispose() {
+    _payeeController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run() async {
+    final payee = _payeeController.text.trim();
+    if (payee.isEmpty || _running) return;
+    final amountText = _amountController.text.trim();
+    final dollars = double.tryParse(amountText);
+    final amountCents = dollars == null ? null : (dollars * 100).round();
+    final accounts = ref.read(accountsProvider).valueOrNull ?? const [];
+    final account =
+        accounts.where((a) => a.id == _accountId).firstOrNull;
+    setState(() => _running = true);
+    try {
+      final trace = await ref.read(autoCategorizeServiceProvider).categorizeWithTrace(
+            payee,
+            amountCents: amountCents,
+            accountId: _accountId,
+            accountType: account?.accountType,
+          );
+      if (mounted) setState(() => _result = trace);
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accounts = ref.watch(accountsProvider).valueOrNull ?? const [];
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: ExpansionTile(
+          leading: const Icon(Icons.science_outlined),
+          title: const Text('Test a payee'),
+          subtitle: Text(
+            'See which rule or cache entry would match',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+          childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          children: [
+            TextField(
+              controller: _payeeController,
+              decoration: const InputDecoration(
+                labelText: 'Payee',
+                hintText: 'e.g. SQ *STARBUCKS #1234 CA 90210',
+                isDense: true,
+              ),
+              onSubmitted: (_) => _run(),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _amountController,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      labelText: 'Amount (optional)',
+                      hintText: '12.34',
+                      prefixText: r'$ ',
+                      isDense: true,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  flex: 2,
+                  child: DropdownButtonFormField<String?>(
+                    initialValue: _accountId,
+                    isExpanded: true,
+                    decoration: const InputDecoration(
+                      labelText: 'Account (optional)',
+                      isDense: true,
+                    ),
+                    items: [
+                      const DropdownMenuItem<String?>(
+                        value: null,
+                        child: Text('(any)'),
+                      ),
+                      for (final a in accounts)
+                        DropdownMenuItem<String?>(
+                          value: a.id,
+                          child: Text(a.name, overflow: TextOverflow.ellipsis),
+                        ),
+                    ],
+                    onChanged: (v) => setState(() => _accountId = v),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed: _running ? null : _run,
+                icon: _running
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.play_arrow),
+                label: const Text('Test'),
+              ),
+            ),
+            if (_result != null) ...[
+              const SizedBox(height: 12),
+              _TestPayeeResult(
+                trace: _result!,
+                categoryNames: widget.categoryNames,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TestPayeeResult extends StatelessWidget {
+  const _TestPayeeResult({required this.trace, required this.categoryNames});
+
+  final CategorizationTrace trace;
+  final Map<String, String> categoryNames;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final categoryName = trace.categoryId == null
+        ? null
+        : (categoryNames[trace.categoryId!] ?? 'Unknown');
+    final (label, color) = switch (trace.source) {
+      CategorizationSource.cache => ('Cache match', scheme.primary),
+      CategorizationSource.rule => ('Rule match', scheme.tertiary),
+      CategorizationSource.none => ('No match', scheme.outline),
+    };
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline, size: 18, color: color),
+              const SizedBox(width: 6),
+              Text(label,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: color,
+                        fontWeight: FontWeight.w600,
+                      )),
+            ],
+          ),
+          const SizedBox(height: 4),
+          if (trace.normalizedPayee.isNotEmpty)
+            Text('Normalized: ${trace.normalizedPayee}',
+                style: Theme.of(context).textTheme.bodySmall),
+          if (categoryName != null)
+            Text('Category: $categoryName',
+                style: Theme.of(context).textTheme.bodyMedium),
+          if (trace.source == CategorizationSource.cache &&
+              trace.cacheConfidence != null)
+            Text(
+              'Confidence: ${(trace.cacheConfidence! * 100).round()}%',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          if (trace.source == CategorizationSource.rule &&
+              trace.matchedRule != null)
+            Text(
+              'Rule: ${trace.matchedRule!.name} (priority ${trace.matchedRule!.priority})',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          if (trace.source == CategorizationSource.none &&
+              trace.cacheConfidence != null)
+            Text(
+              'Cache hint: ${trace.cacheConfidence!.toStringAsFixed(2)} '
+              '(below 0.8 threshold; user prompted instead of auto-applied)',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -146,7 +146,7 @@ class _AutoCategorizeRulesScreenState
 
           return Column(
             children: [
-              _TestPayeePanel(categoryNames: categoryNames),
+              const _TestPayeePanel(),
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
                 child: TextField(
@@ -491,9 +491,7 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
 }
 
 class _TestPayeePanel extends ConsumerStatefulWidget {
-  const _TestPayeePanel({required this.categoryNames});
-
-  final Map<String, String> categoryNames;
+  const _TestPayeePanel();
 
   @override
   ConsumerState<_TestPayeePanel> createState() => _TestPayeePanelState();
@@ -505,32 +503,60 @@ class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
   String? _accountId;
   CategorizationTrace? _result;
   bool _running = false;
+  String? _amountError;
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController.addListener(_validateAmount);
+  }
 
   @override
   void dispose() {
+    _amountController.removeListener(_validateAmount);
     _payeeController.dispose();
     _amountController.dispose();
     super.dispose();
   }
 
+  void _validateAmount() {
+    final text = _amountController.text.trim();
+    final error = (text.isEmpty || double.tryParse(text) != null)
+        ? null
+        : 'Not a valid number';
+    if (error != _amountError) {
+      setState(() => _amountError = error);
+    }
+  }
+
   Future<void> _run() async {
     final payee = _payeeController.text.trim();
-    if (payee.isEmpty || _running) return;
+    if (payee.isEmpty || _running || _amountError != null) return;
     final amountText = _amountController.text.trim();
-    final dollars = double.tryParse(amountText);
-    final amountCents = dollars == null ? null : (dollars * 100).round();
+    final amountCents = amountText.isEmpty
+        ? null
+        : (double.parse(amountText) * 100).round();
     final accounts = ref.read(accountsProvider).valueOrNull ?? const [];
-    final account =
-        accounts.where((a) => a.id == _accountId).firstOrNull;
+    final account = accounts.where((a) => a.id == _accountId).firstOrNull;
+    final messenger = ScaffoldMessenger.of(context);
     setState(() => _running = true);
     try {
-      final trace = await ref.read(autoCategorizeServiceProvider).categorizeWithTrace(
+      final trace = await ref
+          .read(autoCategorizeServiceProvider)
+          .categorizeWithTrace(
             payee,
             amountCents: amountCents,
             accountId: _accountId,
             accountType: account?.accountType,
           );
       if (mounted) setState(() => _result = trace);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _result = null); // don't leave a stale prior result
+      messenger.showSnackBar(SnackBar(
+        content: Text('Test failed: $e'),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ));
     } finally {
       if (mounted) setState(() => _running = false);
     }
@@ -538,7 +564,14 @@ class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
 
   @override
   Widget build(BuildContext context) {
-    final accounts = ref.watch(accountsProvider).valueOrNull ?? const [];
+    final accountsAsync = ref.watch(accountsProvider);
+    final categoriesAsync = ref.watch(allCategoriesProvider);
+    final categoryNames = <String, String>{};
+    categoriesAsync.whenData((cats) {
+      for (final c in cats) {
+        categoryNames[c.id] = c.name;
+      }
+    });
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: Card(
@@ -564,41 +597,28 @@ class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
             ),
             const SizedBox(height: 8),
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Expanded(
                   child: TextField(
                     controller: _amountController,
                     keyboardType:
                         const TextInputType.numberWithOptions(decimal: true),
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'Amount (optional)',
                       hintText: '12.34',
                       prefixText: r'$ ',
                       isDense: true,
+                      errorText: _amountError,
                     ),
                   ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   flex: 2,
-                  child: DropdownButtonFormField<String?>(
-                    initialValue: _accountId,
-                    isExpanded: true,
-                    decoration: const InputDecoration(
-                      labelText: 'Account (optional)',
-                      isDense: true,
-                    ),
-                    items: [
-                      const DropdownMenuItem<String?>(
-                        value: null,
-                        child: Text('(any)'),
-                      ),
-                      for (final a in accounts)
-                        DropdownMenuItem<String?>(
-                          value: a.id,
-                          child: Text(a.name, overflow: TextOverflow.ellipsis),
-                        ),
-                    ],
+                  child: _AccountDropdown(
+                    accountsAsync: accountsAsync,
+                    selectedId: _accountId,
                     onChanged: (v) => setState(() => _accountId = v),
                   ),
                 ),
@@ -608,7 +628,7 @@ class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
             Align(
               alignment: Alignment.centerRight,
               child: FilledButton.icon(
-                onPressed: _running ? null : _run,
+                onPressed: (_running || _amountError != null) ? null : _run,
                 icon: _running
                     ? const SizedBox(
                         width: 14,
@@ -623,11 +643,64 @@ class _TestPayeePanelState extends ConsumerState<_TestPayeePanel> {
               const SizedBox(height: 12),
               _TestPayeeResult(
                 trace: _result!,
-                categoryNames: widget.categoryNames,
+                categoryNames: categoryNames,
               ),
             ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _AccountDropdown extends StatelessWidget {
+  const _AccountDropdown({
+    required this.accountsAsync,
+    required this.selectedId,
+    required this.onChanged,
+  });
+
+  final AsyncValue<List<Account>> accountsAsync;
+  final String? selectedId;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return accountsAsync.when(
+      data: (accounts) => DropdownButtonFormField<String?>(
+        initialValue: selectedId,
+        isExpanded: true,
+        decoration: const InputDecoration(
+          labelText: 'Account (optional)',
+          isDense: true,
+        ),
+        items: [
+          const DropdownMenuItem<String?>(
+            value: null,
+            child: Text('(any)'),
+          ),
+          for (final a in accounts)
+            DropdownMenuItem<String?>(
+              value: a.id,
+              child: Text(a.name, overflow: TextOverflow.ellipsis),
+            ),
+        ],
+        onChanged: onChanged,
+      ),
+      loading: () => const InputDecorator(
+        decoration: InputDecoration(
+          labelText: 'Account (optional)',
+          isDense: true,
+        ),
+        child: Text('Loading accounts…'),
+      ),
+      error: (e, _) => const InputDecorator(
+        decoration: InputDecoration(
+          labelText: 'Account (optional)',
+          isDense: true,
+          errorText: "Couldn't load accounts",
+        ),
+        child: Text('(any)'),
       ),
     );
   }
@@ -672,9 +745,12 @@ class _TestPayeeResult extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 4),
-          if (trace.normalizedPayee.isNotEmpty)
-            Text('Normalized: ${trace.normalizedPayee}',
-                style: Theme.of(context).textTheme.bodySmall),
+          // Always render the normalized line — an empty normalization is
+          // itself a diagnostic signal (the input was stripped to nothing).
+          Text(
+            'Normalized: ${trace.normalizedPayee.isEmpty ? "(empty after normalization)" : trace.normalizedPayee}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
           if (categoryName != null)
             Text('Category: $categoryName',
                 style: Theme.of(context).textTheme.bodyMedium),

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -5,6 +5,8 @@ import 'package:uuid/uuid.dart';
 
 import '../../../core/di/providers.dart';
 import '../../../data/local/database/models.dart';
+import '../../../domain/usecases/categorize/rule_conflicts.dart';
+import '../../shared/utils/provider_invalidation.dart';
 import '../../shared/widgets/category_picker_sheet.dart';
 import 'auto_categorize_providers.dart';
 
@@ -21,11 +23,45 @@ class _AutoCategorizeRulesScreenState
     extends ConsumerState<AutoCategorizeRulesScreen> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
+  bool _isRunning = false;
 
   @override
   void dispose() {
     _searchController.dispose();
     super.dispose();
+  }
+
+  Future<void> _runRecategorize() async {
+    if (_isRunning) return;
+    setState(() => _isRunning = true);
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(const SnackBar(
+      content: Text('Categorizing uncategorized transactions…'),
+      duration: Duration(seconds: 2),
+    ));
+    try {
+      final count =
+          await ref.read(autoCategorizeServiceProvider).categorizeUncategorized();
+      if (!mounted) return;
+      invalidateFinancialData(ref);
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(
+        content: Text(
+          count == 0
+              ? 'No uncategorized transactions matched any rule'
+              : 'Categorized $count transaction${count == 1 ? '' : 's'}',
+        ),
+      ));
+    } catch (e) {
+      if (!mounted) return;
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(
+        content: Text('Re-categorize failed: $e'),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ));
+    } finally {
+      if (mounted) setState(() => _isRunning = false);
+    }
   }
 
   @override
@@ -45,6 +81,17 @@ class _AutoCategorizeRulesScreenState
       appBar: AppBar(
         title: const Text('Auto-Categorization Rules'),
         actions: [
+          IconButton(
+            icon: _isRunning
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.play_arrow),
+            tooltip: 'Re-categorize uncategorized transactions',
+            onPressed: _isRunning ? null : _runRecategorize,
+          ),
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: 'Add rule',
@@ -286,6 +333,21 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     super.dispose();
   }
 
+  List<RuleConflict> _computeConflicts(List<AutoCategorizeRule> existing) {
+    final priority =
+        int.tryParse(_priorityController.text.trim()) ?? 100;
+    return detectRuleConflicts(
+      editingRuleId: widget.rule?.id,
+      payeeContains: _payeeContainsController.text.trim().isEmpty
+          ? null
+          : _payeeContainsController.text.trim(),
+      payeeExact: widget.rule?.payeeExact,
+      categoryId: _selectedCategoryId,
+      priority: priority,
+      existingRules: existing,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // Resolve category name
@@ -296,11 +358,16 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
       });
     }
 
+    final existingRules =
+        ref.watch(autoCategorizeRulesProvider).valueOrNull ?? const [];
+    final conflicts = _computeConflicts(existingRules);
+
     return AlertDialog(
       title: Text(widget.rule == null ? 'Add Rule' : 'Edit Rule'),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             TextField(
               controller: _nameController,
@@ -313,6 +380,7 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
                 labelText: 'Payee Contains',
                 hintText: 'e.g. AMAZON',
               ),
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 12),
             TextField(
@@ -321,6 +389,7 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
                 labelText: 'Priority (lower = higher)',
               ),
               keyboardType: TextInputType.number,
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 12),
             ListTile(
@@ -330,6 +399,13 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
               trailing: const Icon(Icons.chevron_right),
               onTap: () => _pickCategory(context),
             ),
+            if (conflicts.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _ConflictWarning(
+                conflicts: conflicts,
+                priority: int.tryParse(_priorityController.text.trim()) ?? 100,
+              ),
+            ],
           ],
         ),
       ),
@@ -399,5 +475,70 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     }
 
     Navigator.pop(context);
+  }
+}
+
+class _ConflictWarning extends StatelessWidget {
+  const _ConflictWarning({required this.conflicts, required this.priority});
+
+  final List<RuleConflict> conflicts;
+  final int priority;
+
+  String _message(RuleConflict c) {
+    final otherName = c.other.name;
+    switch (c.kind) {
+      case RuleConflictKind.samePatternDifferentCategory:
+        return 'Rule "$otherName" uses the same pattern but maps to a '
+            'different category. Whichever has lower priority wins.';
+      case RuleConflictKind.shadowsOther:
+        return 'Rule "$otherName" is more specific; with this priority it '
+            'would never run.';
+      case RuleConflictKind.shadowedByOther:
+        return 'Rule "$otherName" is more general and runs first; lower '
+            'this rule\'s priority below ${c.other.priority}.';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.amber.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.amber.shade700),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning_amber, color: Colors.amber.shade800, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                conflicts.length == 1
+                    ? 'Possible conflict'
+                    : 'Possible conflicts (${conflicts.length})',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: scheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...conflicts.map(
+            (c) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text(
+                '• ${_message(c)}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/presentation/features/transactions/add_edit_transaction_screen.dart
+++ b/lib/presentation/features/transactions/add_edit_transaction_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:drift/drift.dart' hide Column;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -81,83 +82,127 @@ class _AddEditTransactionScreenState
   /// (normalizedPayee, categoryId) pair within the last 90 days AND no
   /// enabled rule already covers it, prompt the user to create a
   /// persistent `payeeExact` rule.
+  ///
+  /// Wrapped in try/catch so a failure (DB error, etc.) never aborts the
+  /// surrounding save flow — by the time we get here, the transaction
+  /// has already been persisted and the rule prompt is a nice-to-have.
   Future<void> _maybePromptSuggestRule(
     String payeeText,
     String newCategoryId,
   ) async {
-    const minCorrections = 3;
-    const windowDays = 90;
-    final normalized = payee_norm.normalizePayee(payeeText);
-    if (normalized.isEmpty) return;
+    try {
+      const minCorrections = 3;
+      const windowDays = 90;
+      final normalized = payee_norm.normalizePayee(payeeText);
+      if (normalized.isEmpty) {
+        if (kDebugMode) {
+          debugPrint('[SuggestRule] suppressed: normalized payee is empty');
+        }
+        return;
+      }
 
-    final repo = ref.read(autoCategorizeRepositoryProvider);
-    final count = await repo.countRecentCorrectionsForPayee(
-      payeeNormalized: normalized,
-      categoryId: newCategoryId,
-      normalizer: payee_norm.normalizePayee,
-      days: windowDays,
-    );
-    if (count < minCorrections) return;
-
-    final rules = await repo.getEnabledRules();
-    final alreadyCovered = rules.any((r) {
-      if (r.categoryId != newCategoryId) return false;
-      final pe = r.payeeExact?.toUpperCase();
-      if (pe != null && pe == normalized) return true;
-      final pc = r.payeeContains?.toUpperCase();
-      if (pc != null && normalized.contains(pc)) return true;
-      return false;
-    });
-    if (alreadyCovered) return;
-
-    if (!mounted) return;
-    final categoryName = _selectedCategoryName ?? 'this category';
-    final create = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Always categorize this payee?'),
-        content: Text(
-          'You\'ve set "$normalized" to "$categoryName" $count times in '
-          'the last 90 days. Create a permanent rule so future '
-          'transactions categorize automatically?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Not now'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Create rule'),
-          ),
-        ],
-      ),
-    );
-    if (create != true || !mounted) return;
-
-    final now = DateTime.now().millisecondsSinceEpoch;
-    await repo.insertRule(
-      AutoCategorizeRulesCompanion.insert(
-        id: const Uuid().v4(),
-        name: '$normalized → $categoryName',
-        priority: 100,
-        payeeExact: Value(normalized),
+      final repo = ref.read(autoCategorizeRepositoryProvider);
+      final count = await repo.countRecentCorrectionsForPayee(
+        payeeNormalized: normalized,
         categoryId: newCategoryId,
-        createdAt: now,
-        updatedAt: now,
-      ),
-    );
+        days: windowDays,
+      );
+      if (count < minCorrections) {
+        if (kDebugMode) {
+          debugPrint(
+              '[SuggestRule] suppressed: only $count correction(s) for '
+              '"$normalized" → $newCategoryId (need $minCorrections)');
+        }
+        return;
+      }
+
+      final rules = await repo.getEnabledRules();
+      final alreadyCovered = rules.any((r) {
+        if (r.categoryId != newCategoryId) return false;
+        final pe = r.payeeExact?.toUpperCase();
+        if (pe != null && pe == normalized) return true;
+        final pc = r.payeeContains?.toUpperCase();
+        if (pc != null && normalized.contains(pc)) return true;
+        return false;
+      });
+      if (alreadyCovered) {
+        if (kDebugMode) {
+          debugPrint(
+              '[SuggestRule] suppressed: existing enabled rule already '
+              'covers "$normalized" → $newCategoryId');
+        }
+        return;
+      }
+
+      if (!mounted) return;
+      final categoryName = _selectedCategoryName ?? 'this category';
+      final create = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Always categorize this payee?'),
+          content: Text(
+            'You\'ve assigned "$normalized" to "$categoryName" $count times '
+            '(including this one) in the last $windowDays days. Create a '
+            'permanent rule so future transactions categorize automatically?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Not now'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Create rule'),
+            ),
+          ],
+        ),
+      );
+      if (create != true || !mounted) {
+        if (kDebugMode && create != true) {
+          debugPrint('[SuggestRule] dismissed by user');
+        }
+        return;
+      }
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await repo.insertRule(
+        AutoCategorizeRulesCompanion.insert(
+          id: const Uuid().v4(),
+          name: '$normalized → $categoryName',
+          priority: 100,
+          payeeExact: Value(normalized),
+          categoryId: newCategoryId,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    } catch (e, st) {
+      // Don't propagate — the transaction has already been saved by the
+      // time we get here, so a prompt failure shouldn't tear down the
+      // save flow. Log so QA can diagnose silent failures.
+      if (kDebugMode) {
+        debugPrint('[SuggestRule] error during prompt flow: $e\n$st');
+      }
+    }
   }
 
-  /// Resolve the currently selected account's `accountType`. Returns null
-  /// if no account is selected or lookup fails — callers should default to
-  /// the 'standard' cache bucket in that case.
-  Future<String?> _resolveAccountType() async {
+  /// Resolve the currently selected account's `accountType` synchronously
+  /// from the cached `accountsProvider` snapshot. Returns null if no
+  /// account is selected or the snapshot isn't loaded yet — callers
+  /// should default to the 'standard' cache bucket in that case.
+  ///
+  /// We deliberately avoid an async DB roundtrip here because this method
+  /// is called from `_onPayeeChanged` (every 300ms during typing) and the
+  /// account list is already watched by the screen's build method.
+  String? _resolveAccountType() {
     final id = _selectedAccountId;
     if (id == null) return null;
-    final account =
-        await ref.read(accountRepositoryProvider).getAccountById(id);
-    return account?.accountType;
+    final accounts = ref.read(accountsProvider).valueOrNull;
+    if (accounts == null) return null;
+    for (final a in accounts) {
+      if (a.id == id) return a.accountType;
+    }
+    return null;
   }
 
   void _onPayeeChanged() {
@@ -171,7 +216,7 @@ class _AddEditTransactionScreenState
       // matches the user's account context — STARBUCKS in a brokerage
       // account should not auto-suggest Coffee from the checking-account
       // cache, and vice versa.
-      final accountType = await _resolveAccountType();
+      final accountType = _resolveAccountType();
       final categoryId =
           await service.categorize(text, accountType: accountType);
       if (categoryId != null && _selectedCategoryId == null && mounted) {
@@ -276,7 +321,7 @@ class _AddEditTransactionScreenState
       final payeeText = _payeeController.text.trim();
       final autoCatService = ref.read(autoCategorizeServiceProvider);
       if (_selectedCategoryId != null && payeeText.isNotEmpty) {
-        final accountType = await _resolveAccountType();
+        final accountType = _resolveAccountType();
         await autoCatService.recordCategoryAssignment(
           payee: payeeText,
           categoryId: _selectedCategoryId!,

--- a/lib/presentation/features/transactions/add_edit_transaction_screen.dart
+++ b/lib/presentation/features/transactions/add_edit_transaction_screen.dart
@@ -11,6 +11,8 @@ import '../../../core/di/providers.dart';
 import '../../../core/extensions/money_extensions.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../data/local/database/models.dart';
+import '../../../domain/usecases/categorize/payee_normalization.dart'
+    as payee_norm;
 import '../../shared/utils/snackbar_helpers.dart';
 import '../../shared/widgets/category_picker_sheet.dart';
 import '../../shared/widgets/delete_confirmation_dialog.dart';
@@ -75,6 +77,89 @@ class _AddEditTransactionScreenState
     super.dispose();
   }
 
+  /// When a correction has been made N+ times for the same
+  /// (normalizedPayee, categoryId) pair within the last 90 days AND no
+  /// enabled rule already covers it, prompt the user to create a
+  /// persistent `payeeExact` rule.
+  Future<void> _maybePromptSuggestRule(
+    String payeeText,
+    String newCategoryId,
+  ) async {
+    const minCorrections = 3;
+    const windowDays = 90;
+    final normalized = payee_norm.normalizePayee(payeeText);
+    if (normalized.isEmpty) return;
+
+    final repo = ref.read(autoCategorizeRepositoryProvider);
+    final count = await repo.countRecentCorrectionsForPayee(
+      payeeNormalized: normalized,
+      categoryId: newCategoryId,
+      normalizer: payee_norm.normalizePayee,
+      days: windowDays,
+    );
+    if (count < minCorrections) return;
+
+    final rules = await repo.getEnabledRules();
+    final alreadyCovered = rules.any((r) {
+      if (r.categoryId != newCategoryId) return false;
+      final pe = r.payeeExact?.toUpperCase();
+      if (pe != null && pe == normalized) return true;
+      final pc = r.payeeContains?.toUpperCase();
+      if (pc != null && normalized.contains(pc)) return true;
+      return false;
+    });
+    if (alreadyCovered) return;
+
+    if (!mounted) return;
+    final categoryName = _selectedCategoryName ?? 'this category';
+    final create = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Always categorize this payee?'),
+        content: Text(
+          'You\'ve set "$normalized" to "$categoryName" $count times in '
+          'the last 90 days. Create a permanent rule so future '
+          'transactions categorize automatically?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Not now'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Create rule'),
+          ),
+        ],
+      ),
+    );
+    if (create != true || !mounted) return;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await repo.insertRule(
+      AutoCategorizeRulesCompanion.insert(
+        id: const Uuid().v4(),
+        name: '$normalized → $categoryName',
+        priority: 100,
+        payeeExact: Value(normalized),
+        categoryId: newCategoryId,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  /// Resolve the currently selected account's `accountType`. Returns null
+  /// if no account is selected or lookup fails — callers should default to
+  /// the 'standard' cache bucket in that case.
+  Future<String?> _resolveAccountType() async {
+    final id = _selectedAccountId;
+    if (id == null) return null;
+    final account =
+        await ref.read(accountRepositoryProvider).getAccountById(id);
+    return account?.accountType;
+  }
+
   void _onPayeeChanged() {
     _payeeSuggestionTimer?.cancel();
     if (_selectedCategoryId != null) return; // user already picked
@@ -82,7 +167,13 @@ class _AddEditTransactionScreenState
     if (text.length < 3) return;
     _payeeSuggestionTimer = Timer(const Duration(milliseconds: 300), () async {
       final service = ref.read(autoCategorizeServiceProvider);
-      final categoryId = await service.categorize(text);
+      // Pass accountType so the cache bucket (standard vs investment)
+      // matches the user's account context — STARBUCKS in a brokerage
+      // account should not auto-suggest Coffee from the checking-account
+      // cache, and vice versa.
+      final accountType = await _resolveAccountType();
+      final categoryId =
+          await service.categorize(text, accountType: accountType);
       if (categoryId != null && _selectedCategoryId == null && mounted) {
         final category = await ref
             .read(categoryRepositoryProvider)
@@ -185,12 +276,23 @@ class _AddEditTransactionScreenState
       final payeeText = _payeeController.text.trim();
       final autoCatService = ref.read(autoCategorizeServiceProvider);
       if (_selectedCategoryId != null && payeeText.isNotEmpty) {
+        final accountType = await _resolveAccountType();
         await autoCatService.recordCategoryAssignment(
           payee: payeeText,
           categoryId: _selectedCategoryId!,
           transactionId: _isEditing ? widget.transaction!.id : null,
           oldCategoryId: _isEditing ? widget.transaction!.categoryId : null,
+          accountType: accountType,
         );
+
+        // If this was a correction (edit changing the category) and the
+        // same (normalizedPayee, newCategoryId) pair has been corrected
+        // N+ times within the recent window, prompt the user to create a
+        // persistent rule.
+        if (_isEditing &&
+            widget.transaction!.categoryId != _selectedCategoryId) {
+          await _maybePromptSuggestRule(payeeText, _selectedCategoryId!);
+        }
       }
 
       if (!mounted) return;

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:moneymoney/core/constants/app_constants.dart';
 import 'package:moneymoney/data/local/database/app_database.dart';
 import 'package:moneymoney/data/repositories/account_repository.dart';
 import 'package:moneymoney/data/repositories/auto_categorize_repository.dart';
 import 'package:moneymoney/data/repositories/transaction_repository.dart';
 import 'package:moneymoney/domain/usecases/categorize/auto_categorize_service.dart';
+import 'package:moneymoney/domain/usecases/categorize/default_rules_data.dart';
 
 class MockAutoCategorizeRepository extends Mock
     implements AutoCategorizeRepository {}
@@ -374,13 +376,16 @@ void main() {
       expect(captured.confidence.value, equals(0.7)); // 0.5 + 2*0.1
     });
 
-    test('resets on category change', () async {
+    test(
+        'mismatch on useCount=1 entry adopts new category at baseline (flip)',
+        () async {
+      // useCount=1 means no learning to protect; new category wins.
       when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
-          confidence: 0.9,
-          useCount: 4,
+          confidence: 0.6,
+          useCount: 1,
         ),
       );
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
@@ -398,6 +403,69 @@ void main() {
       expect(captured.categoryId.value, equals('cat-groceries'));
       expect(captured.useCount.value, equals(1));
       expect(captured.confidence.value, equals(0.5));
+    });
+
+    test(
+        'mismatch on useCount=3 entry keeps old category, demoted to useCount=2',
+        () async {
+      // useCount=3 is the minimum threshold (confidence=0.8). A single
+      // misclick demotes it to useCount=2/confidence=0.7 — falls below
+      // threshold so the user is prompted next time, but learning is
+      // preserved.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.8,
+          useCount: 3,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      // Old category preserved (dominance-keep)
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(2));
+      expect(captured.confidence.value, closeTo(0.7, 1e-9));
+    });
+
+    test(
+        'mismatch on useCount=8 entry keeps old category, confidence clamps to 1.0',
+        () async {
+      // High-confidence stability: a strong learning signal isn't wiped by
+      // one misclick.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 1.0,
+          useCount: 8,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(7));
+      expect(captured.confidence.value, equals(1.0));
     });
 
     test('logs correction when oldCategoryId differs', () async {
@@ -789,6 +857,67 @@ void main() {
 
       expect(count, equals(0));
       verifyNever(() => mockTxnRepo.updateCategory(any(), any()));
+    });
+  });
+
+  group('default rules data integrity', () {
+    test('no entry uses the bare LOVE substring (false-positive risk)', () {
+      // 'LOVE' as a payeeContains would match any payee with the
+      // substring (e.g. "I LOVE PIZZA"). The actual gas chain is
+      // 'Love's Travel Stops & Country Stores', which appears on
+      // statements as 'LOVES TRAVEL' or "LOVE'S TRAVEL".
+      final bare = defaultMerchantMappings.where((m) => m.$1 == 'LOVE');
+      expect(bare, isEmpty);
+    });
+
+    test('LOVES TRAVEL variants map to Gas', () {
+      final variants = defaultMerchantMappings
+          .where((m) => m.$1.contains('LOVE') && m.$2 == 'Gas')
+          .map((m) => m.$1)
+          .toSet();
+      expect(variants, contains('LOVES TRAVEL'));
+      expect(variants, contains("LOVE'S TRAVEL"));
+    });
+
+    test('Auto Maintenance is a seeded subcategory of Transportation', () {
+      final transport = DefaultCategories.expense
+          .firstWhere((c) => c['name'] == 'Transportation');
+      final children =
+          (transport['children'] as List).cast<String>();
+      expect(children, contains('Auto Maintenance'));
+    });
+
+    test('auto-maintenance merchants map to Auto Maintenance subcategory', () {
+      const autoMerchants = {
+        'JIFFY LUBE', 'VALVOLINE', 'FIRESTONE', 'AUTOZONE', 'PEP BOYS',
+        "O'REILLY", 'ADVANCE AUTO', 'NAPA AUTO', 'MIDAS', 'GOODYEAR',
+        'DISCOUNT TIRE', 'MAACO', 'MEINEKE', 'SAFELITE',
+      };
+      for (final m in autoMerchants) {
+        final rule = defaultMerchantMappings
+            .firstWhere((r) => r.$1 == m, orElse: () => ('', ''));
+        expect(rule.$1, isNotEmpty,
+            reason: '$m should be present in defaultMerchantMappings');
+        expect(rule.$2, equals('Auto Maintenance'),
+            reason: '$m should map to Auto Maintenance, got "${rule.$2}"');
+      }
+    });
+
+    test('every default rule targets a category that exists in seed data', () {
+      final allCategoryNames = <String>{
+        for (final c in DefaultCategories.expense) ...[
+          c['name'] as String,
+          ...((c['children'] as List?) ?? const []).cast<String>(),
+        ],
+        for (final c in DefaultCategories.income) ...[
+          c['name'] as String,
+          ...((c['children'] as List?) ?? const []).cast<String>(),
+        ],
+      };
+      for (final (payee, cat) in defaultMerchantMappings) {
+        expect(allCategoryNames.contains(cat), isTrue,
+            reason: 'Rule "$payee" targets unknown category "$cat"');
+      }
     });
   });
 }

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -934,6 +934,77 @@ void main() {
     });
   });
 
+  group('categorizeWithTrace', () {
+    test('returns source=cache when cache hit above threshold', () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-coffee',
+          confidence: 0.9,
+          useCount: 5,
+        ),
+      );
+
+      final trace = await service.categorizeWithTrace('Starbucks');
+
+      expect(trace.source, equals(CategorizationSource.cache));
+      expect(trace.categoryId, equals('cat-coffee'));
+      expect(trace.normalizedPayee, equals('STARBUCKS'));
+      expect(trace.cacheConfidence, equals(0.9));
+      expect(trace.matchedRule, isNull);
+    });
+
+    test('returns source=rule when cache misses but a rule matches', () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
+        (_) async => [
+          _makeRule(
+            id: 'rule-1',
+            priority: 1,
+            payeeContains: 'STARBUCKS',
+            categoryId: 'cat-coffee',
+          ),
+        ],
+      );
+
+      final trace = await service.categorizeWithTrace('Starbucks');
+
+      expect(trace.source, equals(CategorizationSource.rule));
+      expect(trace.categoryId, equals('cat-coffee'));
+      expect(trace.matchedRule?.id, equals('rule-1'));
+    });
+
+    test('returns source=none when nothing matches; cacheConfidence carried '
+        'through if sub-threshold cache row exists', () async {
+      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN', 'standard'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'UNKNOWN',
+          categoryId: 'cat-guess',
+          confidence: 0.6, // below 0.8 threshold
+          useCount: 2,
+        ),
+      );
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => []);
+
+      final trace = await service.categorizeWithTrace('Unknown');
+
+      expect(trace.source, equals(CategorizationSource.none));
+      expect(trace.categoryId, isNull);
+      expect(trace.cacheConfidence, equals(0.6));
+    });
+
+    test('empty normalized payee returns source=none with empty payee', () async {
+      final trace = await service.categorizeWithTrace('   ');
+      expect(trace.source, equals(CategorizationSource.none));
+      expect(trace.normalizedPayee, isEmpty);
+      expect(trace.categoryId, isNull);
+    });
+  });
+
   group('account-bucket cache isolation', () {
     test('cacheBucket maps investment account types to investment', () {
       expect(AutoCategorizeService.cacheBucket('brokerage'),

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -1003,6 +1003,41 @@ void main() {
       expect(trace.normalizedPayee, isEmpty);
       expect(trace.categoryId, isNull);
     });
+
+    test(
+        'source=rule carries sub-threshold cacheConfidence when a cache row '
+        'exists but is below the auto-apply threshold', () async {
+      // Documented behavior of CategorizationTrace: cacheConfidence is
+      // populated whenever a cache row exists, even when the rule (not the
+      // cache) is what produced the categoryId. Used by the UI to show
+      // "we have a hint but didn't auto-apply" diagnostics.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-guess',
+          confidence: 0.6, // below 0.8 — doesn't drive the result
+          useCount: 2,
+        ),
+      );
+      when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
+        (_) async => [
+          _makeRule(
+            id: 'rule-coffee',
+            priority: 1,
+            payeeContains: 'STARBUCKS',
+            categoryId: 'cat-coffee',
+          ),
+        ],
+      );
+
+      final trace = await service.categorizeWithTrace('Starbucks');
+
+      expect(trace.source, equals(CategorizationSource.rule));
+      expect(trace.categoryId, equals('cat-coffee'));
+      expect(trace.matchedRule?.id, equals('rule-coffee'));
+      expect(trace.cacheConfidence, equals(0.6));
+    });
   });
 
   group('account-bucket cache isolation', () {

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -202,7 +202,7 @@ void main() {
 
   group('categorize', () {
     test('returns categoryId from cache when confidence >= 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -216,7 +216,7 @@ void main() {
     });
 
     test('falls through to rules when cache confidence < 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -232,7 +232,7 @@ void main() {
     });
 
     test('returns null when no cache entry and no rules match', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => []);
@@ -242,7 +242,7 @@ void main() {
     });
 
     test('matches rule with payeeContains', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER'))
+      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -260,7 +260,7 @@ void main() {
     });
 
     test('matches rule with payeeExact', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('NETFLIX'))
+      when(() => mockAutoCatRepo.getCacheEntry('NETFLIX', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -278,7 +278,7 @@ void main() {
     });
 
     test('respects rule priority order (first match wins)', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -302,7 +302,7 @@ void main() {
     });
 
     test('rule with amount range filters correctly', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('STORE', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -331,7 +331,7 @@ void main() {
 
   group('recordCategoryAssignment', () {
     test('creates new cache entry for unknown payee', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -352,7 +352,7 @@ void main() {
     });
 
     test('increments useCount for same category', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -380,7 +380,7 @@ void main() {
         'mismatch on useCount=1 entry adopts new category at baseline (flip)',
         () async {
       // useCount=1 means no learning to protect; new category wins.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -411,7 +411,7 @@ void main() {
       // Boundary case: useCount=2 means penalized=1, which is exactly the
       // >= 1 threshold. A regression that flips the check to > 1 would
       // silently flip useCount=2 entries instead of keeping them.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -441,7 +441,7 @@ void main() {
         () async {
       // When dominance-keep preserves the old categoryId, the correction
       // log must still record the user's actual choice for audit purposes.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -482,7 +482,7 @@ void main() {
       // misclick demotes it to useCount=2/confidence=0.7 — falls below
       // threshold so the user is prompted next time, but learning is
       // preserved.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -513,7 +513,7 @@ void main() {
         () async {
       // High-confidence stability: a strong learning signal isn't wiped by
       // one misclick.
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -539,7 +539,7 @@ void main() {
     });
 
     test('logs correction when oldCategoryId differs', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -557,7 +557,7 @@ void main() {
     });
 
     test('does not log correction when category unchanged', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS'))
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.upsertCacheEntry(any()))
           .thenAnswer((_) async {});
@@ -575,7 +575,7 @@ void main() {
 
   group('categorizeWithPreloadedRules', () {
     test('returns categoryId from cache when confidence >= 0.8', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -602,7 +602,7 @@ void main() {
     });
 
     test('matches preloaded rules when cache misses', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER'))
+      when(() => mockAutoCatRepo.getCacheEntry('WALMART SUPERCENTER', 'standard'))
           .thenAnswer((_) async => null);
 
       final rules = [
@@ -623,7 +623,7 @@ void main() {
     });
 
     test('returns null when no cache and no rules match', () async {
-      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE', 'standard'))
           .thenAnswer((_) async => null);
 
       final rules = [
@@ -653,7 +653,7 @@ void main() {
       ];
 
       // Setup mocks for both paths
-      when(() => mockAutoCatRepo.getCacheEntry('TARGET'))
+      when(() => mockAutoCatRepo.getCacheEntry('TARGET', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => rules);
@@ -694,7 +694,7 @@ void main() {
           .thenAnswer((_) async => txns);
 
       // Starbucks matches cache
-      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard')).thenAnswer(
         (_) async => _makeCacheEntry(
           payeeNormalized: 'STARBUCKS',
           categoryId: 'cat-dining',
@@ -703,7 +703,7 @@ void main() {
       );
 
       // Unknown Store has no match
-      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE'))
+      when(() => mockAutoCatRepo.getCacheEntry('UNKNOWN STORE', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules())
           .thenAnswer((_) async => []);
@@ -758,7 +758,7 @@ void main() {
       when(() => mockAccountRepo.getAllAccounts()).thenAnswer(
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
-      when(() => mockAutoCatRepo.getCacheEntry('DIV - ISHARES RUSSELL 1000'))
+      when(() => mockAutoCatRepo.getCacheEntry('DIV - ISHARES RUSSELL 1000', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -794,8 +794,11 @@ void main() {
 
       when(() => mockTxnRepo.getUncategorizedTransactions())
           .thenAnswer((_) async => txns);
+      // Without accountRepo, accountType resolves to null → 'standard'
+      // bucket. The investment rule won't match because we lack account
+      // context.
       when(() => mockAutoCatRepo.getCacheEntry(
-              'RECORDKEEPING FEE-WELLINGTON'))
+              'RECORDKEEPING FEE-WELLINGTON', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -831,7 +834,7 @@ void main() {
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
       when(() => mockAutoCatRepo.getCacheEntry(
-              'IQPA AUDIT FEES-FIDELITY MID CAP INDEX'))
+              'IQPA AUDIT FEES-FIDELITY MID CAP INDEX', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -870,7 +873,7 @@ void main() {
         (_) async => [_makeAccount(id: 'acc-401k', accountType: '401k')],
       );
       when(() => mockAutoCatRepo.getCacheEntry(
-              'TRANSFERS IN/OUT-FIDELITY 500 INDEX FUND'))
+              'TRANSFERS IN/OUT-FIDELITY 500 INDEX FUND', 'investment'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -909,7 +912,8 @@ void main() {
         (_) async =>
             [_makeAccount(id: 'acc-checking', accountType: 'checking')],
       );
-      when(() => mockAutoCatRepo.getCacheEntry('DIV - VANGUARD FUND'))
+      // Checking account → 'standard' bucket
+      when(() => mockAutoCatRepo.getCacheEntry('DIV - VANGUARD FUND', 'standard'))
           .thenAnswer((_) async => null);
       when(() => mockAutoCatRepo.getEnabledRules()).thenAnswer(
         (_) async => [
@@ -927,6 +931,122 @@ void main() {
 
       expect(count, equals(0));
       verifyNever(() => mockTxnRepo.updateCategory(any(), any()));
+    });
+  });
+
+  group('account-bucket cache isolation', () {
+    test('cacheBucket maps investment account types to investment', () {
+      expect(AutoCategorizeService.cacheBucket('brokerage'),
+          equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('401k'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('ira'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('roth_ira'),
+          equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('hsa'), equals('investment'));
+      expect(AutoCategorizeService.cacheBucket('crypto'), equals('investment'));
+    });
+
+    test('cacheBucket maps non-investment account types to standard', () {
+      expect(AutoCategorizeService.cacheBucket('checking'), equals('standard'));
+      expect(AutoCategorizeService.cacheBucket('savings'), equals('standard'));
+      expect(AutoCategorizeService.cacheBucket('credit_card'),
+          equals('standard'));
+    });
+
+    test('cacheBucket defaults to standard for null accountType', () {
+      expect(AutoCategorizeService.cacheBucket(null), equals('standard'));
+    });
+
+    test('categorize uses investment bucket when accountType is 401k', () async {
+      // Standard bucket entry exists with high confidence, but the call is
+      // for a 401k account — the lookup should target the investment bucket
+      // and miss, falling through to rules (which we leave empty).
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => []);
+
+      final result =
+          await service.categorize('Starbucks', accountType: '401k');
+
+      expect(result, isNull);
+      verify(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .called(1);
+      verifyNever(
+          () => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'));
+    });
+
+    test(
+        'categorize hits separate cache entries per bucket for same payee',
+        () async {
+      // Two different cache entries: STARBUCKS in standard → Coffee, in
+      // investment → Investment Fees. Each call hits the correct row.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          accountBucket: 'standard',
+          categoryId: 'cat-coffee',
+          confidence: 0.9,
+          useCount: 5,
+        ),
+      );
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          accountBucket: 'investment',
+          categoryId: 'cat-fees',
+          confidence: 0.9,
+          useCount: 5,
+        ),
+      );
+
+      final checkingResult =
+          await service.categorize('Starbucks', accountType: 'checking');
+      final brokerageResult =
+          await service.categorize('Starbucks', accountType: 'brokerage');
+
+      expect(checkingResult, equals('cat-coffee'));
+      expect(brokerageResult, equals('cat-fees'));
+    });
+
+    test('recordCategoryAssignment writes to bucket derived from accountType',
+        () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'investment'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-fees',
+        accountType: 'brokerage',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(captured.accountBucket.value, equals('investment'));
+      expect(captured.payeeNormalized.value, equals('STARBUCKS'));
+    });
+
+    test('recordCategoryAssignment defaults to standard bucket when '
+        'accountType is null', () async {
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS', 'standard'))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-coffee',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(captured.accountBucket.value, equals('standard'));
     });
   });
 
@@ -1000,11 +1120,13 @@ PayeeCategoryCacheData _makeCacheEntry({
   required String payeeNormalized,
   required String categoryId,
   required double confidence,
+  String accountBucket = 'standard',
   String source = 'user',
   int useCount = 1,
 }) {
   return PayeeCategoryCacheData(
     payeeNormalized: payeeNormalized,
+    accountBucket: accountBucket,
     categoryId: categoryId,
     confidence: confidence,
     source: source,

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -406,6 +406,76 @@ void main() {
     });
 
     test(
+        'mismatch on useCount=2 entry keeps old category (boundary at >= 1)',
+        () async {
+      // Boundary case: useCount=2 means penalized=1, which is exactly the
+      // >= 1 threshold. A regression that flips the check to > 1 would
+      // silently flip useCount=2 entries instead of keeping them.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.7,
+          useCount: 2,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+      );
+
+      final captured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+
+      expect(captured.categoryId.value, equals('cat-dining'));
+      expect(captured.useCount.value, equals(1));
+      expect(captured.confidence.value, closeTo(0.6, 1e-9));
+    });
+
+    test(
+        'correction is logged even when cache keeps old category on mismatch',
+        () async {
+      // When dominance-keep preserves the old categoryId, the correction
+      // log must still record the user's actual choice for audit purposes.
+      when(() => mockAutoCatRepo.getCacheEntry('STARBUCKS')).thenAnswer(
+        (_) async => _makeCacheEntry(
+          payeeNormalized: 'STARBUCKS',
+          categoryId: 'cat-dining',
+          confidence: 0.8,
+          useCount: 3,
+        ),
+      );
+      when(() => mockAutoCatRepo.upsertCacheEntry(any()))
+          .thenAnswer((_) async {});
+      when(() => mockAutoCatRepo.insertCorrection(any()))
+          .thenAnswer((_) async {});
+
+      await service.recordCategoryAssignment(
+        payee: 'Starbucks',
+        categoryId: 'cat-groceries',
+        transactionId: 'txn-1',
+        oldCategoryId: 'cat-dining',
+      );
+
+      // Cache kept old category.
+      final cacheCaptured = verify(
+        () => mockAutoCatRepo.upsertCacheEntry(captureAny()),
+      ).captured.single as PayeeCategoryCacheCompanion;
+      expect(cacheCaptured.categoryId.value, equals('cat-dining'));
+
+      // But the correction was still logged with the user's intent.
+      final corrCaptured = verify(
+        () => mockAutoCatRepo.insertCorrection(captureAny()),
+      ).captured.single as CategorizationCorrectionsCompanion;
+      expect(corrCaptured.oldCategoryId.value, equals('cat-dining'));
+      expect(corrCaptured.newCategoryId.value, equals('cat-groceries'));
+    });
+
+    test(
         'mismatch on useCount=3 entry keeps old category, demoted to useCount=2',
         () async {
       // useCount=3 is the minimum threshold (confidence=0.8). A single

--- a/test/unit/usecases/categorize/rule_conflicts_test.dart
+++ b/test/unit/usecases/categorize/rule_conflicts_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moneymoney/data/local/database/app_database.dart';
+import 'package:moneymoney/domain/usecases/categorize/rule_conflicts.dart';
+
+AutoCategorizeRule _rule({
+  required String id,
+  String? payeeContains,
+  String? payeeExact,
+  required String categoryId,
+  required int priority,
+}) {
+  return AutoCategorizeRule(
+    id: id,
+    name: 'rule-$id',
+    priority: priority,
+    payeeContains: payeeContains,
+    payeeExact: payeeExact,
+    amountMinCents: null,
+    amountMaxCents: null,
+    accountId: null,
+    categoryId: categoryId,
+    accountType: null,
+    isEnabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+  );
+}
+
+void main() {
+  group('detectRuleConflicts', () {
+    test('returns empty when no existing rules', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: const [],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('returns empty when proposed rule has no payee pattern', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: null,
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-other',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('same payeeContains pattern with same category — no conflict', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-shopping',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('same payeeContains pattern with different category — warns', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'amazon', // case-insensitive
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind,
+          equals(RuleConflictKind.samePatternDifferentCategory));
+    });
+
+    test('this rule shadows a more-specific existing rule with same priority',
+        () {
+      // New rule contains "AMAZON" priority 10. Existing "AMAZON FRESH" priority 50.
+      // New rule's match set strictly contains existing's, and new has lower
+      // priority number → it fires first → existing never runs.
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON FRESH',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
+    });
+
+    test('this rule is shadowed by a more-general existing rule', () {
+      // New rule contains "AMAZON FRESH" priority 50. Existing "AMAZON" priority 10.
+      // Existing matches everything new does (and more), and existing fires
+      // first → new never runs.
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON FRESH',
+        payeeExact: null,
+        categoryId: 'cat-groceries',
+        priority: 50,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-shopping',
+            priority: 10,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowedByOther));
+    });
+
+    test('edit-self does not conflict with self', () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: 'q',
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
+    test('cross-field: new payeeContains "AMAZON" shadows existing exact "AMAZON FRESH"',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeExact: 'AMAZON FRESH',
+            categoryId: 'cat-groceries',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts.length, equals(1));
+      expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
+    });
+
+    test('rules without payee patterns are skipped (amount/accountType only)',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: 'AMAZON',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 10,
+        existingRules: [
+          _rule(
+            id: 'q-no-payee',
+            payeeContains: null,
+            payeeExact: null,
+            categoryId: 'cat-other',
+            priority: 5,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+  });
+}

--- a/test/unit/usecases/categorize/rule_conflicts_test.dart
+++ b/test/unit/usecases/categorize/rule_conflicts_test.dart
@@ -186,6 +186,26 @@ void main() {
       expect(conflicts.first.kind, equals(RuleConflictKind.shadowsOther));
     });
 
+    test('whitespace-only payeeContains is treated as empty (no false matches)',
+        () {
+      final conflicts = detectRuleConflicts(
+        editingRuleId: null,
+        payeeContains: '   ',
+        payeeExact: null,
+        categoryId: 'cat-shopping',
+        priority: 100,
+        existingRules: [
+          _rule(
+            id: 'q',
+            payeeContains: 'AMAZON',
+            categoryId: 'cat-other',
+            priority: 50,
+          ),
+        ],
+      );
+      expect(conflicts, isEmpty);
+    });
+
     test('rules without payee patterns are skipped (amount/accountType only)',
         () {
       final conflicts = detectRuleConflicts(

--- a/test/unit/usecases/categorize/rule_seeder_test.dart
+++ b/test/unit/usecases/categorize/rule_seeder_test.dart
@@ -1,0 +1,359 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moneymoney/data/local/database/app_database.dart';
+import 'package:moneymoney/data/repositories/auto_categorize_repository.dart';
+import 'package:moneymoney/data/repositories/category_repository.dart';
+import 'package:moneymoney/domain/usecases/categorize/rule_seeder.dart';
+
+class MockAutoCategorizeRepository extends Mock
+    implements AutoCategorizeRepository {}
+
+class MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late MockAutoCategorizeRepository autoCatRepo;
+  late MockCategoryRepository categoryRepo;
+  late RuleSeeder seeder;
+
+  setUp(() {
+    autoCatRepo = MockAutoCategorizeRepository();
+    categoryRepo = MockCategoryRepository();
+    seeder = RuleSeeder(categoryRepo, autoCatRepo);
+  });
+
+  setUpAll(() {
+    registerFallbackValue(const AutoCategorizeRulesCompanion());
+  });
+
+  Category cat({
+    required String id,
+    required String name,
+    String? parentId,
+  }) {
+    return Category(
+      id: id,
+      name: name,
+      parentId: parentId,
+      type: 'expense',
+      icon: 'category',
+      color: 0xFF000000,
+      displayOrder: 0,
+      isSystem: false,
+      createdAt: 0,
+      updatedAt: 0,
+      version: 1,
+      syncStatus: 0,
+    );
+  }
+
+  AutoCategorizeRule rule({
+    required String id,
+    required String payeeContains,
+    required String categoryId,
+    required int createdAt,
+    required int updatedAt,
+    int priority = 0,
+  }) {
+    return AutoCategorizeRule(
+      id: id,
+      name: '$payeeContains → cat',
+      priority: priority,
+      payeeContains: payeeContains,
+      payeeExact: null,
+      amountMinCents: null,
+      amountMaxCents: null,
+      accountId: null,
+      categoryId: categoryId,
+      accountType: null,
+      isEnabled: true,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  group('_retargetAutoMaintenanceRules (via seedIfEmpty)', () {
+    test('retargets seeded JIFFY LUBE rule to Auto Maintenance', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      final captured = verify(() => autoCatRepo.updateRule(captureAny()))
+          .captured
+          .cast<AutoCategorizeRulesCompanion>();
+      expect(captured.length, equals(1));
+      expect(captured.first.id.value, equals('rule-jiffy'));
+      expect(captured.first.categoryId.value, equals('automaint'));
+    });
+
+    test('skips rules with updatedAt != createdAt (user-edited)', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-edited',
+              payeeContains: 'AUTOZONE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 2000, // user edited
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips rules already pointing at a different category', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+            cat(id: 'misc', name: 'Miscellaneous'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-already-moved',
+              payeeContains: 'SAFELITE',
+              categoryId: 'misc', // not the Transportation parent
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips non-auto-maintenance merchants', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-shell',
+              payeeContains: 'SHELL', // gas, not maintenance
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('no-op when Auto Maintenance subcategory does not exist', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            // no Auto Maintenance child
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('skips rules with null payeeContains', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'rule-noPattern',
+              name: 'amount-only rule',
+              priority: 0,
+              payeeContains: null,
+              payeeExact: null,
+              amountMinCents: 100,
+              amountMaxCents: 1000,
+              accountId: null,
+              categoryId: 'trans',
+              accountType: null,
+              isEnabled: true,
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      verifyNever(() => autoCatRepo.updateRule(any()));
+    });
+
+    test('retargets multiple rules and reports backfill via return value',
+        () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'trans', name: 'Transportation'),
+            cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
+          ]);
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'rule-jiffy',
+              payeeContains: 'JIFFY LUBE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+            rule(
+              id: 'rule-autozone',
+              payeeContains: 'AUTOZONE',
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+            rule(
+              id: 'rule-oreilly',
+              payeeContains: "O'REILLY",
+              categoryId: 'trans',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      verify(() => autoCatRepo.updateRule(any())).called(3);
+    });
+  });
+
+  group('_backfillMissingDefaultRules (via seedIfEmpty)', () {
+    test('inserts a missing general rule for an existing user', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // Existing user only has KROGER; missing TESLA SUPERCHARGER and others.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'existing',
+              payeeContains: 'KROGER',
+              categoryId: 'gas',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      final result = await seeder.seedIfEmpty();
+
+      expect(result, isTrue);
+      final captured = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Should contain TESLA SUPERCHARGER → Gas (new 2025-era rule).
+      final hasTesla = captured.any((c) =>
+          c.payeeContains.value == 'TESLA SUPERCHARGER' &&
+          c.categoryId.value == 'gas');
+      expect(hasTesla, isTrue);
+      // Should NOT re-insert KROGER (already exists).
+      final hasKroger =
+          captured.any((c) => c.payeeContains.value == 'KROGER');
+      expect(hasKroger, isFalse);
+    });
+
+    test('skips general rules whose payeeContains already exists', () async {
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // User has all the EV charging rules already.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'user-tesla',
+              payeeContains: 'TESLA SUPERCHARGER',
+              categoryId: 'gas',
+              createdAt: 1000,
+              updatedAt: 2000, // user-edited; dedup still applies
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      // Anything inserted should not include TESLA SUPERCHARGER.
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      final hasTeslaSupercharger = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaSupercharger, isFalse);
+    });
+
+    test('inserts investment rule with same payeeContains as general rule',
+        () async {
+      // An investment rule with the same payeeContains but a different
+      // accountType has a distinct dedup key, so should be inserted.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'interest', name: 'Interest'),
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      // User has a general 'INTEREST' rule but no investment-scoped one.
+      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+            rule(
+              id: 'general',
+              payeeContains: 'INTEREST',
+              categoryId: 'interest',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Investment 'INTEREST' rule for brokerage should still be inserted.
+      final hasInvestmentInterest = inserted.any((c) =>
+          c.payeeContains.value == 'INTEREST' &&
+          c.accountType.value == 'brokerage');
+      expect(hasInvestmentInterest, isTrue);
+    });
+  });
+}

--- a/test/unit/usecases/categorize/rule_seeder_test.dart
+++ b/test/unit/usecases/categorize/rule_seeder_test.dart
@@ -78,7 +78,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -88,17 +88,17 @@ void main() {
             ),
           ]);
       when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
-      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRulesCategoryBatch(any(), any())).thenAnswer((_) async {});
 
       final result = await seeder.seedIfEmpty();
 
       expect(result, isTrue);
-      final captured = verify(() => autoCatRepo.updateRule(captureAny()))
+      final captured = verify(() =>
+              autoCatRepo.updateRulesCategoryBatch(captureAny(), any()))
           .captured
-          .cast<AutoCategorizeRulesCompanion>();
+          .single as Map<String, String>;
       expect(captured.length, equals(1));
-      expect(captured.first.id.value, equals('rule-jiffy'));
-      expect(captured.first.categoryId.value, equals('automaint'));
+      expect(captured['rule-jiffy'], equals('automaint'));
     });
 
     test('skips rules with updatedAt != createdAt (user-edited)', () async {
@@ -107,7 +107,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-edited',
               payeeContains: 'AUTOZONE',
@@ -120,7 +120,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips rules already pointing at a different category', () async {
@@ -130,7 +130,7 @@ void main() {
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
             cat(id: 'misc', name: 'Miscellaneous'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-already-moved',
               payeeContains: 'SAFELITE',
@@ -143,7 +143,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips non-auto-maintenance merchants', () async {
@@ -152,7 +152,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-shell',
               payeeContains: 'SHELL', // gas, not maintenance
@@ -165,7 +165,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('no-op when Auto Maintenance subcategory does not exist', () async {
@@ -174,7 +174,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             // no Auto Maintenance child
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -187,7 +187,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('skips rules with null payeeContains', () async {
@@ -196,7 +196,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             const AutoCategorizeRule(
               id: 'rule-noPattern',
               name: 'amount-only rule',
@@ -217,7 +217,7 @@ void main() {
 
       await seeder.seedIfEmpty();
 
-      verifyNever(() => autoCatRepo.updateRule(any()));
+      verifyNever(() => autoCatRepo.updateRulesCategoryBatch(any(), any()));
     });
 
     test('retargets multiple rules and reports backfill via return value',
@@ -227,7 +227,7 @@ void main() {
             cat(id: 'trans', name: 'Transportation'),
             cat(id: 'automaint', name: 'Auto Maintenance', parentId: 'trans'),
           ]);
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'rule-jiffy',
               payeeContains: 'JIFFY LUBE',
@@ -251,12 +251,19 @@ void main() {
             ),
           ]);
       when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
-      when(() => autoCatRepo.updateRule(any())).thenAnswer((_) async {});
+      when(() => autoCatRepo.updateRulesCategoryBatch(any(), any())).thenAnswer((_) async {});
 
       final result = await seeder.seedIfEmpty();
 
       expect(result, isTrue);
-      verify(() => autoCatRepo.updateRule(any())).called(3);
+      // Batched: one call with all three retargets in the map.
+      final captured = verify(() =>
+              autoCatRepo.updateRulesCategoryBatch(captureAny(), any()))
+          .captured
+          .single as Map<String, String>;
+      expect(captured.length, equals(3));
+      expect(captured.keys, containsAll(['rule-jiffy', 'rule-autozone', 'rule-oreilly']));
+      expect(captured.values, everyElement(equals('automaint')));
     });
   });
 
@@ -267,7 +274,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // Existing user only has KROGER; missing TESLA SUPERCHARGER and others.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'existing',
               payeeContains: 'KROGER',
@@ -301,7 +308,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // User has all the EV charging rules already.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'user-tesla',
               payeeContains: 'TESLA SUPERCHARGER',
@@ -323,6 +330,85 @@ void main() {
       expect(hasTeslaSupercharger, isFalse);
     });
 
+    test('does NOT duplicate a default rule that the user has disabled',
+        () async {
+      // Regression test for the bug where dedup used getEnabledRules,
+      // missing user-disabled rules and re-inserting duplicates on every
+      // upgrade.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+          ]);
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'disabled-tesla',
+              name: 'TESLA SUPERCHARGER → Gas',
+              priority: 100,
+              payeeContains: 'TESLA SUPERCHARGER',
+              payeeExact: null,
+              amountMinCents: null,
+              amountMaxCents: null,
+              accountId: null,
+              categoryId: 'gas',
+              accountType: null,
+              isEnabled: false, // user disabled
+              createdAt: 1000,
+              updatedAt: 2000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      // Critical: should NOT re-insert TESLA SUPERCHARGER even though
+      // the existing rule is disabled.
+      final hasTeslaDuplicate = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaDuplicate, isFalse,
+          reason: 'disabled rule should still dedupe');
+    });
+
+    test('does NOT duplicate a default rule the user has customized', () async {
+      // Companion to the disabled-rule test: an enabled rule with the same
+      // payeeContains but a user-customized name/category should also dedupe.
+      when(() => autoCatRepo.hasRules()).thenAnswer((_) async => true);
+      when(() => categoryRepo.getAllCategories()).thenAnswer((_) async => [
+            cat(id: 'gas', name: 'Gas'),
+            cat(id: 'misc', name: 'Miscellaneous'),
+          ]);
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
+            const AutoCategorizeRule(
+              id: 'custom-tesla',
+              name: 'My custom Tesla rule',
+              priority: 5,
+              payeeContains: 'TESLA SUPERCHARGER',
+              payeeExact: null,
+              amountMinCents: null,
+              amountMaxCents: null,
+              accountId: null,
+              categoryId: 'misc', // user mapped it elsewhere
+              accountType: null,
+              isEnabled: true,
+              createdAt: 1000,
+              updatedAt: 2000,
+            ),
+          ]);
+      when(() => autoCatRepo.insertRules(any())).thenAnswer((_) async {});
+
+      await seeder.seedIfEmpty();
+
+      final inserted = verify(() => autoCatRepo.insertRules(captureAny()))
+          .captured
+          .single as List<AutoCategorizeRulesCompanion>;
+      final hasTeslaDuplicate = inserted
+          .any((c) => c.payeeContains.value == 'TESLA SUPERCHARGER');
+      expect(hasTeslaDuplicate, isFalse,
+          reason: 'user-customized rule should dedupe; their choice wins');
+    });
+
     test('inserts investment rule with same payeeContains as general rule',
         () async {
       // An investment rule with the same payeeContains but a different
@@ -333,7 +419,7 @@ void main() {
             cat(id: 'gas', name: 'Gas'),
           ]);
       // User has a general 'INTEREST' rule but no investment-scoped one.
-      when(() => autoCatRepo.getEnabledRules()).thenAnswer((_) async => [
+      when(() => autoCatRepo.getAllRules()).thenAnswer((_) async => [
             rule(
               id: 'general',
               payeeContains: 'INTEREST',


### PR DESCRIPTION
## Summary

Phase 3.1 of auto-categorization improvements (stacks on PR #143 → #142). Adds a "Test a payee" debug panel to the rules screen and refactors `categorize()` to delegate to a new `categorizeWithTrace()` method. **Base set to `feature/auto-categorize-phase-2` so the diff shows only Phase 3.1 work** — GitHub will retarget the base to `master` automatically as parent PRs merge.

330 tests pass. Analyze clean.

## Changes

### Service refactor (commit `2aad715`)
- New `CategorizationTrace` class + `CategorizationSource` enum for full provenance.
- `categorizeWithTrace()` and `categorizeWithPreloadedRulesAndTrace()` are the new "source of truth" methods.
- `categorize()` and `categorizeWithPreloadedRules()` are now one-liners that delegate via `.categoryId` — no logic duplication.

### Test-a-payee UI (commit `f583a75`)
- Collapsible `ExpansionTile` at the top of `AutoCategorizeRulesScreen`.
- Inputs: Payee (required), Amount (optional dollars), Account dropdown (optional).
- Result card shows: source (cache / rule / none), normalized payee, resolved category name, confidence for cache hits, matched rule name + priority for rule hits, sub-threshold cache hint when applicable.

### Tests
4 new cases for `categorizeWithTrace`:
- cache hit above threshold → `source=cache`
- cache miss but rule matches → `source=rule` with `matchedRule`
- no match with sub-threshold cache row → `source=none` + `cacheConfidence`
- empty normalized payee → `source=none`

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` passes (330/330)
- [ ] Open Settings → Auto-Categorization Rules → tap "Test a payee" → expand
- [ ] Type `SQ *STARBUCKS #1234 CA 90210` → tap Test → result card shows normalized "STARBUCKS", matched rule, category
- [ ] Try a payee that has no rule and no cache entry → "No match" with normalized payee
- [ ] Try with optional Account dropdown set to a brokerage account → confirm bucket switching works (different result vs no account selected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)