### PR TITLE
feat(categorize): 3.2 — drag-reorder rule priorities

### DIFF
--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -101,6 +101,28 @@ class AutoCategorizeRepository {
     });
   }
 
+  /// Reassign priorities for a list of rules in a single batched transaction.
+  /// [updates] is an ordered list of (id, priority) pairs. Used by
+  /// drag-reorder UI to rewrite the full ordering atomically — a mid-loop
+  /// failure can't leave the table half-reordered.
+  Future<void> reassignPriorities(
+    List<(String id, int priority)> updates,
+    int updatedAt,
+  ) {
+    return _db.batch((batch) {
+      for (final (id, priority) in updates) {
+        batch.update(
+          _db.autoCategorizeRules,
+          AutoCategorizeRulesCompanion(
+            priority: Value(priority),
+            updatedAt: Value(updatedAt),
+          ),
+          where: (r) => r.id.equals(id),
+        );
+      }
+    });
+  }
+
   /// Retarget multiple rules' categoryId in a single batched transaction.
   /// Used by RuleSeeder's one-shot retargets so a mid-loop failure can't
   /// leave the table partially updated.

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -192,36 +192,49 @@ class _AutoCategorizeRulesScreenState
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
                       )
-                    : ListView.builder(
-                        itemCount: filtered.length,
-                        itemBuilder: (context, index) {
-                          final rule = filtered[index];
-                          return _RuleTile(
-                            rule: rule,
-                            categoryNames: categoryNames,
-                            onTap: () =>
-                                _showRuleDialog(context, ref, rule: rule),
-                            onToggle: (value) {
-                              final now =
-                                  DateTime.now().millisecondsSinceEpoch;
-                              ref
-                                  .read(autoCategorizeRepositoryProvider)
-                                  .updateRule(
-                                    AutoCategorizeRulesCompanion(
-                                      id: Value(rule.id),
-                                      isEnabled: Value(value),
-                                      updatedAt: Value(now),
-                                    ),
-                                  );
+                    : query.isEmpty
+                        ? ReorderableListView.builder(
+                            // Reorder is only enabled on the unfiltered list —
+                            // dragging within a filtered subset doesn't have
+                            // sensible semantics for the global priority axis.
+                            itemCount: filtered.length,
+                            buildDefaultDragHandles: false,
+                            onReorder: (oldIndex, newIndex) =>
+                                _onReorder(filtered, oldIndex, newIndex),
+                            itemBuilder: (context, index) {
+                              final rule = filtered[index];
+                              return _RuleTile(
+                                key: ValueKey(rule.id),
+                                rule: rule,
+                                index: index,
+                                reorderable: true,
+                                categoryNames: categoryNames,
+                                onTap: () =>
+                                    _showRuleDialog(context, ref, rule: rule),
+                                onToggle: (value) => _toggleRule(rule, value),
+                                onDelete: () =>
+                                    _confirmAndDelete(context, rule),
+                              );
                             },
-                            onDelete: () {
-                              ref
-                                  .read(autoCategorizeRepositoryProvider)
-                                  .deleteRule(rule.id);
+                          )
+                        : ListView.builder(
+                            itemCount: filtered.length,
+                            itemBuilder: (context, index) {
+                              final rule = filtered[index];
+                              return _RuleTile(
+                                key: ValueKey(rule.id),
+                                rule: rule,
+                                index: index,
+                                reorderable: false,
+                                categoryNames: categoryNames,
+                                onTap: () =>
+                                    _showRuleDialog(context, ref, rule: rule),
+                                onToggle: (value) => _toggleRule(rule, value),
+                                onDelete: () =>
+                                    _confirmAndDelete(context, rule),
+                              );
                             },
-                          );
-                        },
-                      ),
+                          ),
               ),
             ],
           );
@@ -237,17 +250,85 @@ class _AutoCategorizeRulesScreenState
       builder: (ctx) => _RuleDialog(rule: rule),
     );
   }
+
+  void _toggleRule(AutoCategorizeRule rule, bool value) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    ref.read(autoCategorizeRepositoryProvider).updateRule(
+          AutoCategorizeRulesCompanion(
+            id: Value(rule.id),
+            isEnabled: Value(value),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> _confirmAndDelete(
+      BuildContext context, AutoCategorizeRule rule) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Rule'),
+        content: Text('Delete "${rule.name}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await ref.read(autoCategorizeRepositoryProvider).deleteRule(rule.id);
+    }
+  }
+
+  Future<void> _onReorder(
+    List<AutoCategorizeRule> visible,
+    int oldIndex,
+    int newIndex,
+  ) async {
+    if (newIndex > oldIndex) newIndex -= 1;
+    if (oldIndex == newIndex) return;
+    final reordered = [...visible];
+    final moved = reordered.removeAt(oldIndex);
+    reordered.insert(newIndex, moved);
+    final now = DateTime.now().millisecondsSinceEpoch;
+    // Step 10 leaves gaps for future manual priority inserts.
+    final updates = <(String, int)>[
+      for (var i = 0; i < reordered.length; i++) (reordered[i].id, (i + 1) * 10),
+    ];
+    try {
+      await ref
+          .read(autoCategorizeRepositoryProvider)
+          .reassignPriorities(updates, now);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Reorder failed: $e'),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ));
+    }
+  }
 }
 
 class _RuleTile extends StatelessWidget {
   final AutoCategorizeRule rule;
+  final int index;
+  final bool reorderable;
   final Map<String, String> categoryNames;
   final VoidCallback onTap;
   final ValueChanged<bool> onToggle;
   final VoidCallback onDelete;
 
   const _RuleTile({
+    super.key,
     required this.rule,
+    required this.index,
+    required this.reorderable,
     required this.categoryNames,
     required this.onTap,
     required this.onToggle,
@@ -256,8 +337,40 @@ class _RuleTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Drag handle + explicit delete button when inside ReorderableListView;
+    // Dismissible swipe-to-delete inside ListView when search is active
+    // (Dismissible doesn't compose cleanly inside ReorderableListView).
+    if (reorderable) {
+      return ListTile(
+        leading: ReorderableDragStartListener(
+          index: index,
+          child: const Icon(Icons.drag_handle),
+        ),
+        title: Text(rule.name),
+        subtitle: Text(
+          _ruleDescription(),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete rule',
+              onPressed: onDelete,
+            ),
+            Switch(
+              value: rule.isEnabled,
+              onChanged: onToggle,
+            ),
+          ],
+        ),
+        onTap: onTap,
+      );
+    }
     return Dismissible(
-      key: ValueKey(rule.id),
+      key: ValueKey('dismiss-${rule.id}'),
       direction: DismissDirection.endToStart,
       background: Container(
         alignment: Alignment.centerRight,

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart' hide Column;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
@@ -232,6 +233,16 @@ class _AutoCategorizeRulesScreenState
                                 onToggle: (value) => _toggleRule(rule, value),
                                 onDelete: () =>
                                     _confirmAndDelete(context, rule),
+                                onDismissConfirmed: () {
+                                  // confirmDismiss already prompted; skip
+                                  // the second confirmation dialog.
+                                  final messenger =
+                                      ScaffoldMessenger.of(context);
+                                  final errorColor =
+                                      Theme.of(context).colorScheme.error;
+                                  _deleteRuleSilently(
+                                      rule, messenger, errorColor);
+                                },
                               );
                             },
                           ),
@@ -251,19 +262,37 @@ class _AutoCategorizeRulesScreenState
     );
   }
 
-  void _toggleRule(AutoCategorizeRule rule, bool value) {
+  Future<void> _toggleRule(AutoCategorizeRule rule, bool value) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
     final now = DateTime.now().millisecondsSinceEpoch;
-    ref.read(autoCategorizeRepositoryProvider).updateRule(
-          AutoCategorizeRulesCompanion(
-            id: Value(rule.id),
-            isEnabled: Value(value),
-            updatedAt: Value(now),
-          ),
-        );
+    try {
+      await ref.read(autoCategorizeRepositoryProvider).updateRule(
+            AutoCategorizeRulesCompanion(
+              id: Value(rule.id),
+              isEnabled: Value(value),
+              updatedAt: Value(now),
+            ),
+          );
+    } catch (e) {
+      if (kDebugMode) debugPrint('toggleRule failed: $e');
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(
+        content: Text(
+          value ? "Couldn't enable rule" : "Couldn't disable rule",
+        ),
+        backgroundColor: errorColor,
+      ));
+    }
   }
 
+  /// Delete with a confirmation dialog. Used by the reorder-mode trailing
+  /// IconButton. Search-mode Dismissible has its own inline confirm dialog
+  /// (via `confirmDismiss`) so it calls [_deleteRuleSilently] instead.
   Future<void> _confirmAndDelete(
       BuildContext context, AutoCategorizeRule rule) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -281,8 +310,25 @@ class _AutoCategorizeRulesScreenState
         ],
       ),
     );
-    if (confirmed == true) {
+    if (confirmed != true) return;
+    await _deleteRuleSilently(rule, messenger, errorColor);
+  }
+
+  /// Delete without prompting. Caller must already have confirmation.
+  Future<void> _deleteRuleSilently(
+    AutoCategorizeRule rule,
+    ScaffoldMessengerState messenger,
+    Color errorColor,
+  ) async {
+    try {
       await ref.read(autoCategorizeRepositoryProvider).deleteRule(rule.id);
+    } catch (e) {
+      if (kDebugMode) debugPrint('deleteRule failed: $e');
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(
+        content: const Text("Couldn't delete rule"),
+        backgroundColor: errorColor,
+      ));
     }
   }
 
@@ -301,15 +347,22 @@ class _AutoCategorizeRulesScreenState
     final updates = <(String, int)>[
       for (var i = 0; i < reordered.length; i++) (reordered[i].id, (i + 1) * 10),
     ];
+    // Capture context-derived values pre-await per the project's
+    // established pattern (mirrors _runRecategorize + _TestPayeePanel._run).
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
     try {
       await ref
           .read(autoCategorizeRepositoryProvider)
           .reassignPriorities(updates, now);
     } catch (e) {
+      if (kDebugMode) debugPrint('reassignPriorities failed: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text('Reorder failed: $e'),
-        backgroundColor: Theme.of(context).colorScheme.error,
+      messenger.showSnackBar(SnackBar(
+        content: const Text(
+          'Could not save new order — please try again',
+        ),
+        backgroundColor: errorColor,
       ));
     }
   }
@@ -323,6 +376,9 @@ class _RuleTile extends StatelessWidget {
   final VoidCallback onTap;
   final ValueChanged<bool> onToggle;
   final VoidCallback onDelete;
+  // Optional: skip-the-second-dialog delete used by the Dismissible path
+  // (search mode). When null, Dismissible falls back to [onDelete].
+  final VoidCallback? onDismissConfirmed;
 
   const _RuleTile({
     super.key,
@@ -333,6 +389,7 @@ class _RuleTile extends StatelessWidget {
     required this.onTap,
     required this.onToggle,
     required this.onDelete,
+    this.onDismissConfirmed,
   });
 
   @override
@@ -395,7 +452,11 @@ class _RuleTile extends StatelessWidget {
           ],
         ),
       ),
-      onDismissed: (_) => onDelete(),
+      // confirmDismiss already prompted the user — don't open a second
+      // confirmation dialog from onDelete. Caller passes onDismissConfirmed
+      // to delete directly; fall back to onDelete only if not provided.
+      onDismissed: (_) =>
+          (onDismissConfirmed ?? onDelete)(),
       child: ListTile(
         title: Text(rule.name),
         subtitle: Text(
@@ -445,9 +506,23 @@ class _RuleDialogState extends ConsumerState<_RuleDialog> {
     _nameController = TextEditingController(text: widget.rule?.name ?? '');
     _payeeContainsController =
         TextEditingController(text: widget.rule?.payeeContains ?? '');
+    // New-rule default priority: max(existing) + 10 so it lands cleanly at
+    // the bottom of any drag-reordered list (which uses step-10 priorities).
+    // A hardcoded 100 would silently collide with the 10th drag-reordered
+    // rule. Fall back to 10 when no rules exist.
+    final defaultPriority = widget.rule?.priority ?? _nextPriorityDefault();
     _priorityController =
-        TextEditingController(text: '${widget.rule?.priority ?? 100}');
+        TextEditingController(text: '$defaultPriority');
     _selectedCategoryId = widget.rule?.categoryId;
+  }
+
+  int _nextPriorityDefault() {
+    final rules = ref.read(autoCategorizeRulesProvider).valueOrNull;
+    if (rules == null || rules.isEmpty) return 10;
+    final maxPriority = rules.map((r) => r.priority).reduce(
+          (a, b) => a > b ? a : b,
+        );
+    return maxPriority + 10;
   }
 
   @override

--- a/test/unit/repositories/auto_categorize_repository_test.dart
+++ b/test/unit/repositories/auto_categorize_repository_test.dart
@@ -1,0 +1,89 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moneymoney/data/local/database/app_database.dart';
+import 'package:moneymoney/data/repositories/auto_categorize_repository.dart';
+
+void main() {
+  late AppDatabase database;
+  late AutoCategorizeRepository repo;
+
+  setUp(() {
+    database = AppDatabase(NativeDatabase.memory());
+    repo = AutoCategorizeRepository(database);
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  AutoCategorizeRulesCompanion makeRule({
+    required String id,
+    required int priority,
+    String? payeeContains = 'TEST',
+  }) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return AutoCategorizeRulesCompanion.insert(
+      id: id,
+      name: 'rule-$id',
+      priority: priority,
+      categoryId: 'cat-1',
+      createdAt: now,
+      updatedAt: now,
+      payeeContains: Value(payeeContains),
+    );
+  }
+
+  group('reassignPriorities', () {
+    test('rewrites priorities in the supplied order with step 10', () async {
+      await repo.insertRules([
+        makeRule(id: 'a', priority: 100),
+        makeRule(id: 'b', priority: 200),
+        makeRule(id: 'c', priority: 300),
+      ]);
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      // Caller submits new order: c, a, b (priorities should become 10, 20, 30).
+      await repo.reassignPriorities([
+        ('c', 10),
+        ('a', 20),
+        ('b', 30),
+      ], now);
+
+      final rules = await repo.getAllRules();
+      final byId = {for (final r in rules) r.id: r};
+      expect(byId['c']!.priority, 10);
+      expect(byId['a']!.priority, 20);
+      expect(byId['b']!.priority, 30);
+      // updatedAt is bumped on every reordered row.
+      expect(byId['a']!.updatedAt, now);
+      expect(byId['b']!.updatedAt, now);
+      expect(byId['c']!.updatedAt, now);
+    });
+
+    test('empty updates list is a no-op', () async {
+      await repo.insertRules([makeRule(id: 'a', priority: 100)]);
+      final original = (await repo.getAllRules()).single;
+
+      await repo.reassignPriorities([], original.updatedAt + 1000);
+
+      final after = (await repo.getAllRules()).single;
+      expect(after.priority, 100);
+      expect(after.updatedAt, original.updatedAt);
+    });
+
+    test('ignores ids that do not exist (no-op for missing rules)', () async {
+      await repo.insertRules([makeRule(id: 'a', priority: 100)]);
+      final now = DateTime.now().millisecondsSinceEpoch;
+
+      await repo.reassignPriorities([
+        ('a', 10),
+        ('ghost', 20),
+      ], now);
+
+      final rules = await repo.getAllRules();
+      expect(rules.length, 1);
+      expect(rules.single.priority, 10);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- New `AutoCategorizeRepository.reassignPriorities(updates, updatedAt)` rewrites priorities atomically in one batch.
- Rules screen uses `ReorderableListView.builder` when search is empty; falls back to plain `ListView.builder` when filtering (reordering a filtered subset isn't a meaningful operation on the global priority axis).
- `_RuleTile` in reorder mode: leading drag handle (`ReorderableDragStartListener`) + explicit trailing delete `IconButton` with confirmation. Search mode keeps swipe-to-delete via `Dismissible` (which doesn't compose cleanly inside `ReorderableListView`).
- Step-10 priorities (10, 20, 30…) leave gaps for future manual inserts.
- Reorder failure surfaces a themed snackbar; Drift stream re-emits the canonical ordering either way.

## Test plan

- [x] `flutter analyze` clean on touched files
- [x] Full suite: 334/334 tests pass
- [x] 3 new repo tests: step-10 happy path, empty-updates no-op, unknown-id no-op
- [ ] Manual: drag a rule from row 5 → row 2 → priority order persists across app restart
- [ ] Manual: type a search query → drag handles disappear, swipe-to-delete still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)