### PR TITLE
feat(categorize): 3.3 — rule hit counts + low-use surfacing

### DIFF
--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -113,6 +113,8 @@ class AutoCategorizeRules extends Table {
   TextColumn get categoryId => text()();
   TextColumn get accountType => text().nullable()();
   BoolColumn get isEnabled => boolean().withDefault(const Constant(true))();
+  IntColumn get hitCount => integer().withDefault(const Constant(0))();
+  IntColumn get lastHitAt => integer().nullable()();
   IntColumn get createdAt => integer()();
   IntColumn get updatedAt => integer()();
 
@@ -417,7 +419,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -562,6 +564,21 @@ class AppDatabase extends _$AppDatabase {
               await customStatement('DROP TABLE payee_category_cache');
               await customStatement(
                 'ALTER TABLE payee_category_cache_new RENAME TO payee_category_cache',
+              );
+            });
+          }
+
+          // v7 → v8: Rule hit-count observability. Adds hit_count and
+          // last_hit_at to auto_categorize_rules so the UI can surface
+          // low-use rules. Wrapped in a transaction so partial failure
+          // leaves the schema at v7.
+          if (from < 8) {
+            await transaction(() async {
+              await customStatement(
+                'ALTER TABLE auto_categorize_rules ADD COLUMN hit_count INTEGER NOT NULL DEFAULT 0',
+              );
+              await customStatement(
+                'ALTER TABLE auto_categorize_rules ADD COLUMN last_hit_at INTEGER',
               );
             });
           }

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -570,8 +570,13 @@ class AppDatabase extends _$AppDatabase {
 
           // v7 → v8: Rule hit-count observability. Adds hit_count and
           // last_hit_at to auto_categorize_rules so the UI can surface
-          // low-use rules. Wrapped in a transaction so partial failure
-          // leaves the schema at v7.
+          // low-use rules.
+          //
+          // Drift's onUpgrade is already executed inside a transaction —
+          // the inner transaction() call below is a savepoint that
+          // mirrors the v6→v7 pattern for consistency, but the outer
+          // Drift transaction is what protects partial-failure atomicity
+          // across the two ALTER statements.
           if (from < 8) {
             await transaction(() async {
               await customStatement(

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -3712,6 +3712,29 @@ class $AutoCategorizeRulesTable extends AutoCategorizeRules
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _hitCountMeta = const VerificationMeta(
+    'hitCount',
+  );
+  @override
+  late final GeneratedColumn<int> hitCount = GeneratedColumn<int>(
+    'hit_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _lastHitAtMeta = const VerificationMeta(
+    'lastHitAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastHitAt = GeneratedColumn<int>(
+    'last_hit_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -3747,6 +3770,8 @@ class $AutoCategorizeRulesTable extends AutoCategorizeRules
     categoryId,
     accountType,
     isEnabled,
+    hitCount,
+    lastHitAt,
     createdAt,
     updatedAt,
   ];
@@ -3845,6 +3870,18 @@ class $AutoCategorizeRulesTable extends AutoCategorizeRules
         isEnabled.isAcceptableOrUnknown(data['is_enabled']!, _isEnabledMeta),
       );
     }
+    if (data.containsKey('hit_count')) {
+      context.handle(
+        _hitCountMeta,
+        hitCount.isAcceptableOrUnknown(data['hit_count']!, _hitCountMeta),
+      );
+    }
+    if (data.containsKey('last_hit_at')) {
+      context.handle(
+        _lastHitAtMeta,
+        lastHitAt.isAcceptableOrUnknown(data['last_hit_at']!, _lastHitAtMeta),
+      );
+    }
     if (data.containsKey('created_at')) {
       context.handle(
         _createdAtMeta,
@@ -3914,6 +3951,14 @@ class $AutoCategorizeRulesTable extends AutoCategorizeRules
         DriftSqlType.bool,
         data['${effectivePrefix}is_enabled'],
       )!,
+      hitCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}hit_count'],
+      )!,
+      lastHitAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_hit_at'],
+      ),
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}created_at'],
@@ -3944,6 +3989,8 @@ class AutoCategorizeRule extends DataClass
   final String categoryId;
   final String? accountType;
   final bool isEnabled;
+  final int hitCount;
+  final int? lastHitAt;
   final int createdAt;
   final int updatedAt;
   const AutoCategorizeRule({
@@ -3958,6 +4005,8 @@ class AutoCategorizeRule extends DataClass
     required this.categoryId,
     this.accountType,
     required this.isEnabled,
+    required this.hitCount,
+    this.lastHitAt,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -3987,6 +4036,10 @@ class AutoCategorizeRule extends DataClass
       map['account_type'] = Variable<String>(accountType);
     }
     map['is_enabled'] = Variable<bool>(isEnabled);
+    map['hit_count'] = Variable<int>(hitCount);
+    if (!nullToAbsent || lastHitAt != null) {
+      map['last_hit_at'] = Variable<int>(lastHitAt);
+    }
     map['created_at'] = Variable<int>(createdAt);
     map['updated_at'] = Variable<int>(updatedAt);
     return map;
@@ -4017,6 +4070,10 @@ class AutoCategorizeRule extends DataClass
           ? const Value.absent()
           : Value(accountType),
       isEnabled: Value(isEnabled),
+      hitCount: Value(hitCount),
+      lastHitAt: lastHitAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastHitAt),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
     );
@@ -4039,6 +4096,8 @@ class AutoCategorizeRule extends DataClass
       categoryId: serializer.fromJson<String>(json['categoryId']),
       accountType: serializer.fromJson<String?>(json['accountType']),
       isEnabled: serializer.fromJson<bool>(json['isEnabled']),
+      hitCount: serializer.fromJson<int>(json['hitCount']),
+      lastHitAt: serializer.fromJson<int?>(json['lastHitAt']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
     );
@@ -4058,6 +4117,8 @@ class AutoCategorizeRule extends DataClass
       'categoryId': serializer.toJson<String>(categoryId),
       'accountType': serializer.toJson<String?>(accountType),
       'isEnabled': serializer.toJson<bool>(isEnabled),
+      'hitCount': serializer.toJson<int>(hitCount),
+      'lastHitAt': serializer.toJson<int?>(lastHitAt),
       'createdAt': serializer.toJson<int>(createdAt),
       'updatedAt': serializer.toJson<int>(updatedAt),
     };
@@ -4075,6 +4136,8 @@ class AutoCategorizeRule extends DataClass
     String? categoryId,
     Value<String?> accountType = const Value.absent(),
     bool? isEnabled,
+    int? hitCount,
+    Value<int?> lastHitAt = const Value.absent(),
     int? createdAt,
     int? updatedAt,
   }) => AutoCategorizeRule(
@@ -4095,6 +4158,8 @@ class AutoCategorizeRule extends DataClass
     categoryId: categoryId ?? this.categoryId,
     accountType: accountType.present ? accountType.value : this.accountType,
     isEnabled: isEnabled ?? this.isEnabled,
+    hitCount: hitCount ?? this.hitCount,
+    lastHitAt: lastHitAt.present ? lastHitAt.value : this.lastHitAt,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
@@ -4123,6 +4188,8 @@ class AutoCategorizeRule extends DataClass
           ? data.accountType.value
           : this.accountType,
       isEnabled: data.isEnabled.present ? data.isEnabled.value : this.isEnabled,
+      hitCount: data.hitCount.present ? data.hitCount.value : this.hitCount,
+      lastHitAt: data.lastHitAt.present ? data.lastHitAt.value : this.lastHitAt,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -4142,6 +4209,8 @@ class AutoCategorizeRule extends DataClass
           ..write('categoryId: $categoryId, ')
           ..write('accountType: $accountType, ')
           ..write('isEnabled: $isEnabled, ')
+          ..write('hitCount: $hitCount, ')
+          ..write('lastHitAt: $lastHitAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -4161,6 +4230,8 @@ class AutoCategorizeRule extends DataClass
     categoryId,
     accountType,
     isEnabled,
+    hitCount,
+    lastHitAt,
     createdAt,
     updatedAt,
   );
@@ -4179,6 +4250,8 @@ class AutoCategorizeRule extends DataClass
           other.categoryId == this.categoryId &&
           other.accountType == this.accountType &&
           other.isEnabled == this.isEnabled &&
+          other.hitCount == this.hitCount &&
+          other.lastHitAt == this.lastHitAt &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -4195,6 +4268,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
   final Value<String> categoryId;
   final Value<String?> accountType;
   final Value<bool> isEnabled;
+  final Value<int> hitCount;
+  final Value<int?> lastHitAt;
   final Value<int> createdAt;
   final Value<int> updatedAt;
   final Value<int> rowid;
@@ -4210,6 +4285,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
     this.categoryId = const Value.absent(),
     this.accountType = const Value.absent(),
     this.isEnabled = const Value.absent(),
+    this.hitCount = const Value.absent(),
+    this.lastHitAt = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -4226,6 +4303,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
     required String categoryId,
     this.accountType = const Value.absent(),
     this.isEnabled = const Value.absent(),
+    this.hitCount = const Value.absent(),
+    this.lastHitAt = const Value.absent(),
     required int createdAt,
     required int updatedAt,
     this.rowid = const Value.absent(),
@@ -4247,6 +4326,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
     Expression<String>? categoryId,
     Expression<String>? accountType,
     Expression<bool>? isEnabled,
+    Expression<int>? hitCount,
+    Expression<int>? lastHitAt,
     Expression<int>? createdAt,
     Expression<int>? updatedAt,
     Expression<int>? rowid,
@@ -4263,6 +4344,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
       if (categoryId != null) 'category_id': categoryId,
       if (accountType != null) 'account_type': accountType,
       if (isEnabled != null) 'is_enabled': isEnabled,
+      if (hitCount != null) 'hit_count': hitCount,
+      if (lastHitAt != null) 'last_hit_at': lastHitAt,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
@@ -4281,6 +4364,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
     Value<String>? categoryId,
     Value<String?>? accountType,
     Value<bool>? isEnabled,
+    Value<int>? hitCount,
+    Value<int?>? lastHitAt,
     Value<int>? createdAt,
     Value<int>? updatedAt,
     Value<int>? rowid,
@@ -4297,6 +4382,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
       categoryId: categoryId ?? this.categoryId,
       accountType: accountType ?? this.accountType,
       isEnabled: isEnabled ?? this.isEnabled,
+      hitCount: hitCount ?? this.hitCount,
+      lastHitAt: lastHitAt ?? this.lastHitAt,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
@@ -4339,6 +4426,12 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
     if (isEnabled.present) {
       map['is_enabled'] = Variable<bool>(isEnabled.value);
     }
+    if (hitCount.present) {
+      map['hit_count'] = Variable<int>(hitCount.value);
+    }
+    if (lastHitAt.present) {
+      map['last_hit_at'] = Variable<int>(lastHitAt.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<int>(createdAt.value);
     }
@@ -4365,6 +4458,8 @@ class AutoCategorizeRulesCompanion extends UpdateCompanion<AutoCategorizeRule> {
           ..write('categoryId: $categoryId, ')
           ..write('accountType: $accountType, ')
           ..write('isEnabled: $isEnabled, ')
+          ..write('hitCount: $hitCount, ')
+          ..write('lastHitAt: $lastHitAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')
@@ -14702,6 +14797,8 @@ typedef $$AutoCategorizeRulesTableCreateCompanionBuilder =
       required String categoryId,
       Value<String?> accountType,
       Value<bool> isEnabled,
+      Value<int> hitCount,
+      Value<int?> lastHitAt,
       required int createdAt,
       required int updatedAt,
       Value<int> rowid,
@@ -14719,6 +14816,8 @@ typedef $$AutoCategorizeRulesTableUpdateCompanionBuilder =
       Value<String> categoryId,
       Value<String?> accountType,
       Value<bool> isEnabled,
+      Value<int> hitCount,
+      Value<int?> lastHitAt,
       Value<int> createdAt,
       Value<int> updatedAt,
       Value<int> rowid,
@@ -14785,6 +14884,16 @@ class $$AutoCategorizeRulesTableFilterComposer
 
   ColumnFilters<bool> get isEnabled => $composableBuilder(
     column: $table.isEnabled,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get hitCount => $composableBuilder(
+    column: $table.hitCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastHitAt => $composableBuilder(
+    column: $table.lastHitAt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -14863,6 +14972,16 @@ class $$AutoCategorizeRulesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get hitCount => $composableBuilder(
+    column: $table.hitCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastHitAt => $composableBuilder(
+    column: $table.lastHitAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get createdAt => $composableBuilder(
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
@@ -14928,6 +15047,12 @@ class $$AutoCategorizeRulesTableAnnotationComposer
   GeneratedColumn<bool> get isEnabled =>
       $composableBuilder(column: $table.isEnabled, builder: (column) => column);
 
+  GeneratedColumn<int> get hitCount =>
+      $composableBuilder(column: $table.hitCount, builder: (column) => column);
+
+  GeneratedColumn<int> get lastHitAt =>
+      $composableBuilder(column: $table.lastHitAt, builder: (column) => column);
+
   GeneratedColumn<int> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
@@ -14989,6 +15114,8 @@ class $$AutoCategorizeRulesTableTableManager
                 Value<String> categoryId = const Value.absent(),
                 Value<String?> accountType = const Value.absent(),
                 Value<bool> isEnabled = const Value.absent(),
+                Value<int> hitCount = const Value.absent(),
+                Value<int?> lastHitAt = const Value.absent(),
                 Value<int> createdAt = const Value.absent(),
                 Value<int> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -15004,6 +15131,8 @@ class $$AutoCategorizeRulesTableTableManager
                 categoryId: categoryId,
                 accountType: accountType,
                 isEnabled: isEnabled,
+                hitCount: hitCount,
+                lastHitAt: lastHitAt,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,
@@ -15021,6 +15150,8 @@ class $$AutoCategorizeRulesTableTableManager
                 required String categoryId,
                 Value<String?> accountType = const Value.absent(),
                 Value<bool> isEnabled = const Value.absent(),
+                Value<int> hitCount = const Value.absent(),
+                Value<int?> lastHitAt = const Value.absent(),
                 required int createdAt,
                 required int updatedAt,
                 Value<int> rowid = const Value.absent(),
@@ -15036,6 +15167,8 @@ class $$AutoCategorizeRulesTableTableManager
                 categoryId: categoryId,
                 accountType: accountType,
                 isEnabled: isEnabled,
+                hitCount: hitCount,
+                lastHitAt: lastHitAt,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 rowid: rowid,

--- a/lib/data/repositories/auto_categorize_repository.dart
+++ b/lib/data/repositories/auto_categorize_repository.dart
@@ -144,6 +144,24 @@ class AutoCategorizeRepository {
     });
   }
 
+  /// Increment hit counts for multiple rules in a single batched transaction.
+  /// [hitsByRuleId] maps rule id → increment delta. [lastHitAt] is the wall
+  /// clock for the most recent matching event; we apply the same value to
+  /// every updated row because the batch represents one "categorize" event.
+  Future<void> incrementHitCounts(
+    Map<String, int> hitsByRuleId,
+    int lastHitAt,
+  ) {
+    return _db.batch((batch) {
+      for (final entry in hitsByRuleId.entries) {
+        batch.customStatement(
+          'UPDATE auto_categorize_rules SET hit_count = hit_count + ?, last_hit_at = ? WHERE id = ?',
+          [entry.value, lastHitAt, entry.key],
+        );
+      }
+    });
+  }
+
   /// Check if any rules exist.
   Future<bool> hasRules() async {
     final count = _db.autoCategorizeRules.id.count();

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -250,6 +250,18 @@ class AutoCategorizeService {
     return _autoCatRepo.getEnabledRules();
   }
 
+  /// Flush a batch of rule-hit counts to the repository in one write.
+  /// Used by bulk-categorization callers (sync, CSV import, the manual
+  /// re-categorize button) so the hot loop can accumulate hits in-memory
+  /// and pay a single write at the end.
+  Future<void> flushHitCounts(Map<String, int> hits) {
+    if (hits.isEmpty) return Future.value();
+    return _autoCatRepo.incrementHitCounts(
+      hits,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
   /// Categorize using pre-loaded rules (avoids per-transaction DB query for rules).
   /// Tier 1 cache lookup is still per-transaction (each payee may differ).
   Future<String?> categorizeWithPreloadedRules(
@@ -459,7 +471,9 @@ class AutoCategorizeService {
 
   /// Auto-categorize all uncategorized transactions.
   ///
-  /// Returns the number of transactions that were categorized.
+  /// Returns the number of transactions that were categorized. As a side
+  /// effect, increments `hit_count` (and updates `last_hit_at`) on each
+  /// rule that fired during the run via a single batched write at the end.
   Future<int> categorizeUncategorized() async {
     final uncategorized = await _transactionRepo.getUncategorizedTransactions();
     if (uncategorized.isEmpty) return 0;
@@ -475,21 +489,27 @@ class AutoCategorizeService {
       }
     }
 
+    final hits = <String, int>{}; // ruleId -> match count
     var count = 0;
     for (final txn in uncategorized) {
-      final categoryId = await categorizeWithPreloadedRules(
+      final trace = await categorizeWithPreloadedRulesAndTrace(
         txn.payee,
         rules,
         amountCents: txn.amountCents,
         accountId: txn.accountId,
         accountType: accountTypeMap[txn.accountId],
       );
-      if (categoryId != null) {
-        await _transactionRepo.updateCategory(txn.id, categoryId);
+      if (trace.categoryId != null) {
+        if (trace.matchedRule != null) {
+          hits.update(trace.matchedRule!.id, (v) => v + 1,
+              ifAbsent: () => 1);
+        }
+        await _transactionRepo.updateCategory(txn.id, trace.categoryId!);
         count++;
       }
     }
 
+    await flushHitCounts(hits);
     return count;
   }
 }

--- a/lib/domain/usecases/categorize/auto_categorize_service.dart
+++ b/lib/domain/usecases/categorize/auto_categorize_service.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../data/local/database/app_database.dart';
@@ -254,12 +255,23 @@ class AutoCategorizeService {
   /// Used by bulk-categorization callers (sync, CSV import, the manual
   /// re-categorize button) so the hot loop can accumulate hits in-memory
   /// and pay a single write at the end.
-  Future<void> flushHitCounts(Map<String, int> hits) {
-    if (hits.isEmpty) return Future.value();
-    return _autoCatRepo.incrementHitCounts(
-      hits,
-      DateTime.now().millisecondsSinceEpoch,
-    );
+  ///
+  /// This is **best-effort telemetry** and never throws. If the underlying
+  /// batch write fails (disk full, DB locked, etc.) we log under kDebugMode
+  /// and swallow — a hit-count flush failure must not flip a successful
+  /// sync/import/recategorize to a user-facing error state.
+  Future<void> flushHitCounts(Map<String, int> hits) async {
+    if (hits.isEmpty) return;
+    try {
+      await _autoCatRepo.incrementHitCounts(
+        hits,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('flushHitCounts failed for ${hits.length} rule(s): $e');
+      }
+    }
   }
 
   /// Categorize using pre-loaded rules (avoids per-transaction DB query for rules).

--- a/lib/domain/usecases/import/csv_import_service.dart
+++ b/lib/domain/usecases/import/csv_import_service.dart
@@ -374,23 +374,30 @@ class CsvImportService {
       if (toInsert.isNotEmpty) {
         await _transactionRepo.insertTransactions(toInsert);
 
-        // Auto-categorize imported transactions (load rules once for batch)
+        // Auto-categorize imported transactions (load rules once for batch).
+        // Trace variant so we can accumulate per-rule hits and flush once.
         final rules = await _autoCategorizeService.loadEnabledRules();
+        final hits = <String, int>{};
         for (final companion in toInsert) {
-          final categoryId =
-              await _autoCategorizeService.categorizeWithPreloadedRules(
+          final trace = await _autoCategorizeService
+              .categorizeWithPreloadedRulesAndTrace(
             companion.payee.value,
             rules,
             amountCents: companion.amountCents.value,
             accountId: accountId,
           );
-          if (categoryId != null) {
+          if (trace.categoryId != null) {
             await _transactionRepo.updateCategory(
               companion.id.value,
-              categoryId,
+              trace.categoryId!,
             );
+            if (trace.matchedRule != null) {
+              hits.update(trace.matchedRule!.id, (v) => v + 1,
+                  ifAbsent: () => 1);
+            }
           }
         }
+        await _autoCategorizeService.flushHitCounts(hits);
       }
       importedCount = toInsert.length;
     } catch (e) {

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -176,6 +176,9 @@ class SimplefinSyncService {
 
       // Preload categorization rules once for the entire sync
       final rules = await _autoCategorizeService.loadEnabledRules();
+      // Accumulate rule-hit counts across the whole sync; flushed once
+      // before the per-connection summary is recorded.
+      final hits = <String, int>{};
 
       // Load linked accounts once (same query for every SF account)
       final linkedAccounts =
@@ -339,17 +342,22 @@ class SimplefinSyncService {
             ),
           );
 
-          // Auto-categorize the new transaction
-          final categoryId =
-              await _autoCategorizeService.categorizeWithPreloadedRules(
+          // Auto-categorize the new transaction (trace variant so we can
+          // accumulate rule hits for low-use surfacing).
+          final trace =
+              await _autoCategorizeService.categorizeWithPreloadedRulesAndTrace(
             sfTxn.description,
             rules,
             amountCents: effectiveAmount(sfTxn.amountCents),
             accountId: localAccount.id,
             accountType: localAccount.accountType,
           );
-          if (categoryId != null) {
-            await _transactionRepo.updateCategory(txnId, categoryId);
+          if (trace.categoryId != null) {
+            await _transactionRepo.updateCategory(txnId, trace.categoryId!);
+            if (trace.matchedRule != null) {
+              hits.update(trace.matchedRule!.id, (v) => v + 1,
+                  ifAbsent: () => 1);
+            }
           }
 
           acctImported++;
@@ -368,6 +376,9 @@ class SimplefinSyncService {
           skippedFuzzy: acctSkippedFuzzy,
         ));
       }
+
+      // Flush accumulated rule-hit counts in a single batched write.
+      await _autoCategorizeService.flushHitCounts(hits);
 
       // Update connection
       final nowMillis = now.millisecondsSinceEpoch;

--- a/lib/domain/usecases/sync/simplefin_sync_service.dart
+++ b/lib/domain/usecases/sync/simplefin_sync_service.dart
@@ -176,8 +176,12 @@ class SimplefinSyncService {
 
       // Preload categorization rules once for the entire sync
       final rules = await _autoCategorizeService.loadEnabledRules();
-      // Accumulate rule-hit counts across the whole sync; flushed once
-      // before the per-connection summary is recorded.
+      // Accumulate rule-hit counts across this connection's accounts;
+      // flushed once at the end of the connection. SyncOrchestrator calls
+      // syncConnection() per connection sequentially, so a multi-connection
+      // sync flushes once per connection rather than once globally — fine
+      // for telemetry, and simpler than threading state through the
+      // orchestrator.
       final hits = <String, int>{};
 
       // Load linked accounts once (same query for every SF account)

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -243,8 +243,9 @@ class _AutoCategorizeRulesScreenState
                 child: filtered.isEmpty
                     ? Center(
                         child: Text(
-                          'No rules match "$_searchQuery"',
+                          _emptyStateMessage(query),
                           style: Theme.of(context).textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
                         ),
                       )
                     : (query.isEmpty &&
@@ -318,6 +319,18 @@ class _AutoCategorizeRulesScreenState
       context: context,
       builder: (ctx) => _RuleDialog(rule: rule),
     );
+  }
+
+  /// Empty-state message that honors which filters produced the empty set.
+  /// Prevents the user from seeing `No rules match ""` when the low-use
+  /// filter is active with no search query.
+  String _emptyStateMessage(String query) {
+    if (query.isNotEmpty) return 'No rules match "$_searchQuery"';
+    if (_showLowUseOnly) {
+      return 'No low-use rules — every rule has matched at least once '
+          'or is less than 90 days old';
+    }
+    return 'No rules to show';
   }
 
   /// Apply the current sort to a rules list. Returns a new list; the input

--- a/lib/presentation/features/settings/auto_categorize_rules_screen.dart
+++ b/lib/presentation/features/settings/auto_categorize_rules_screen.dart
@@ -22,11 +22,22 @@ class AutoCategorizeRulesScreen extends ConsumerStatefulWidget {
       _AutoCategorizeRulesScreenState();
 }
 
+/// Sort options for the rules list. Default is priority ascending, which
+/// matches the matching engine's evaluation order.
+enum _RuleSort { priority, name, hits, lastHit }
+
 class _AutoCategorizeRulesScreenState
     extends ConsumerState<AutoCategorizeRulesScreen> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
   bool _isRunning = false;
+  _RuleSort _sort = _RuleSort.priority;
+  bool _showLowUseOnly = false;
+
+  // A rule is "low-use" if it has never matched in production AND has been
+  // around long enough to have had a fair chance. 90 days matches the
+  // suggestion-banner correction window so both surfaces use the same scale.
+  static const _lowUseAgeDaysThreshold = 90;
 
   @override
   void dispose() {
@@ -93,6 +104,24 @@ class _AutoCategorizeRulesScreenState
       appBar: AppBar(
         title: const Text('Auto-Categorization Rules'),
         actions: [
+          PopupMenuButton<_RuleSort>(
+            icon: const Icon(Icons.sort),
+            tooltip: 'Sort rules',
+            initialValue: _sort,
+            onSelected: (v) => setState(() => _sort = v),
+            itemBuilder: (_) => const [
+              PopupMenuItem(
+                value: _RuleSort.priority,
+                child: Text('Priority (default)'),
+              ),
+              PopupMenuItem(value: _RuleSort.name, child: Text('Name')),
+              PopupMenuItem(value: _RuleSort.hits, child: Text('Most hits')),
+              PopupMenuItem(
+                value: _RuleSort.lastHit,
+                child: Text('Recently used'),
+              ),
+            ],
+          ),
           IconButton(
             icon: _isRunning
                 ? const SizedBox(
@@ -129,7 +158,7 @@ class _AutoCategorizeRulesScreenState
 
           // Filter rules by search query
           final query = _searchQuery.toLowerCase();
-          final filtered = query.isEmpty
+          final searched = query.isEmpty
               ? rules
               : rules.where((rule) {
                   final name = rule.name.toLowerCase();
@@ -144,6 +173,19 @@ class _AutoCategorizeRulesScreenState
                       payeeExact.contains(query) ||
                       catName.contains(query);
                 }).toList();
+
+          // Apply low-use filter (hitCount=0 AND older than 90 days).
+          final filterCutoff = DateTime.now()
+              .subtract(const Duration(days: _lowUseAgeDaysThreshold))
+              .millisecondsSinceEpoch;
+          final lowUseFiltered = _showLowUseOnly
+              ? searched
+                  .where((r) => r.hitCount == 0 && r.createdAt < filterCutoff)
+                  .toList()
+              : searched;
+
+          // Apply sort.
+          final filtered = _applySort(lowUseFiltered);
 
           return Column(
             children: [
@@ -171,20 +213,32 @@ class _AutoCategorizeRulesScreenState
                       setState(() => _searchQuery = value),
                 ),
               ),
-              if (query.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      '${filtered.length} of ${rules.length} rules',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Row(
+                  children: [
+                    FilterChip(
+                      label: const Text('Low-use rules'),
+                      selected: _showLowUseOnly,
+                      onSelected: (v) =>
+                          setState(() => _showLowUseOnly = v),
+                      tooltip:
+                          'Never matched and at least 90 days old',
                     ),
-                  ),
+                    const Spacer(),
+                    if (query.isNotEmpty || _showLowUseOnly)
+                      Text(
+                        '${filtered.length} of ${rules.length} rules',
+                        style:
+                            Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                ),
+                      ),
+                  ],
                 ),
+              ),
               Expanded(
                 child: filtered.isEmpty
                     ? Center(
@@ -193,11 +247,15 @@ class _AutoCategorizeRulesScreenState
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
                       )
-                    : query.isEmpty
+                    : (query.isEmpty &&
+                            _sort == _RuleSort.priority &&
+                            !_showLowUseOnly)
                         ? ReorderableListView.builder(
-                            // Reorder is only enabled on the unfiltered list —
-                            // dragging within a filtered subset doesn't have
-                            // sensible semantics for the global priority axis.
+                            // Reorder is only enabled on the unfiltered list
+                            // with the default priority sort — dragging within
+                            // a filtered subset or a non-priority view doesn't
+                            // have sensible semantics for the global priority
+                            // axis.
                             itemCount: filtered.length,
                             buildDefaultDragHandles: false,
                             onReorder: (oldIndex, newIndex) =>
@@ -260,6 +318,35 @@ class _AutoCategorizeRulesScreenState
       context: context,
       builder: (ctx) => _RuleDialog(rule: rule),
     );
+  }
+
+  /// Apply the current sort to a rules list. Returns a new list; the input
+  /// is not mutated. Priority sort returns the input as-is because Drift
+  /// already returns rules ordered by ascending priority.
+  List<AutoCategorizeRule> _applySort(List<AutoCategorizeRule> input) {
+    if (_sort == _RuleSort.priority) return input;
+    final sorted = [...input];
+    switch (_sort) {
+      case _RuleSort.priority:
+        break; // unreachable
+      case _RuleSort.name:
+        sorted.sort(
+          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+        );
+      case _RuleSort.hits:
+        sorted.sort((a, b) => b.hitCount.compareTo(a.hitCount));
+      case _RuleSort.lastHit:
+        // null lastHitAt sorts to the bottom (i.e. "least recently used").
+        sorted.sort((a, b) {
+          final aHit = a.lastHitAt;
+          final bHit = b.lastHitAt;
+          if (aHit == null && bHit == null) return 0;
+          if (aHit == null) return 1;
+          if (bHit == null) return -1;
+          return bHit.compareTo(aHit);
+        });
+    }
+    return sorted;
   }
 
   Future<void> _toggleRule(AutoCategorizeRule rule, bool value) async {
@@ -480,6 +567,9 @@ class _RuleTile extends StatelessWidget {
     final catName = categoryNames[rule.categoryId] ?? 'Unknown';
     parts.add('→ $catName');
     parts.add('Priority: ${rule.priority}');
+    parts.add(rule.hitCount == 0
+        ? 'Never used'
+        : '${rule.hitCount} ${rule.hitCount == 1 ? "hit" : "hits"}');
     return parts.join(' · ');
   }
 }

--- a/test/unit/repositories/auto_categorize_repository_test.dart
+++ b/test/unit/repositories/auto_categorize_repository_test.dart
@@ -1,4 +1,4 @@
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moneymoney/data/local/database/app_database.dart';
@@ -84,6 +84,69 @@ void main() {
       final rules = await repo.getAllRules();
       expect(rules.length, 1);
       expect(rules.single.priority, 10);
+    });
+  });
+
+  group('incrementHitCounts', () {
+    test('adds the given delta to existing hit_count and updates last_hit_at',
+        () async {
+      await repo.insertRules([
+        makeRule(id: 'a', priority: 100),
+        makeRule(id: 'b', priority: 200),
+        makeRule(id: 'c', priority: 300),
+      ]);
+      final t0 = 1_700_000_000_000;
+
+      // First flush: a gets 3 hits, b gets 1.
+      await repo.incrementHitCounts({'a': 3, 'b': 1}, t0);
+      var rules = await repo.getAllRules();
+      var byId = {for (final r in rules) r.id: r};
+      expect(byId['a']!.hitCount, 3);
+      expect(byId['b']!.hitCount, 1);
+      expect(byId['c']!.hitCount, 0);
+      expect(byId['a']!.lastHitAt, t0);
+      expect(byId['b']!.lastHitAt, t0);
+      expect(byId['c']!.lastHitAt, isNull);
+
+      // Second flush: a gets +2 more (cumulative 5), c gets 4 (first hit).
+      final t1 = t0 + 60_000;
+      await repo.incrementHitCounts({'a': 2, 'c': 4}, t1);
+      rules = await repo.getAllRules();
+      byId = {for (final r in rules) r.id: r};
+      expect(byId['a']!.hitCount, 5);
+      expect(byId['a']!.lastHitAt, t1);
+      // b was unchanged in second flush.
+      expect(byId['b']!.hitCount, 1);
+      expect(byId['b']!.lastHitAt, t0);
+      expect(byId['c']!.hitCount, 4);
+      expect(byId['c']!.lastHitAt, t1);
+    });
+
+    test('empty hits map is a no-op', () async {
+      await repo.insertRules([makeRule(id: 'a', priority: 100)]);
+
+      await repo.incrementHitCounts({}, 1_700_000_000_000);
+
+      final rule = (await repo.getAllRules()).single;
+      expect(rule.hitCount, 0);
+      expect(rule.lastHitAt, isNull);
+    });
+
+    test('updates only the targeted rule', () async {
+      await repo.insertRules([
+        makeRule(id: 'a', priority: 100),
+        makeRule(id: 'b', priority: 200),
+      ]);
+      final t = 1_700_000_000_000;
+
+      await repo.incrementHitCounts({'b': 1}, t);
+
+      final rules = await repo.getAllRules();
+      final byId = {for (final r in rules) r.id: r};
+      expect(byId['a']!.hitCount, 0);
+      expect(byId['a']!.lastHitAt, isNull);
+      expect(byId['b']!.hitCount, 1);
+      expect(byId['b']!.lastHitAt, t);
     });
   });
 }

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -766,6 +766,37 @@ void main() {
           .called(1);
     });
 
+    test(
+        'completes successfully even if the hit-count flush throws '
+        '(telemetry must not fail the user-facing operation)', () async {
+      final rule = _makeRule(
+        id: 'rule-x',
+        payeeContains: 'STARBUCKS',
+        categoryId: 'cat-x',
+        priority: 10,
+      );
+      when(() => mockTxnRepo.getUncategorizedTransactions())
+          .thenAnswer((_) async => [
+                _makeTransaction(
+                    id: 'txn-1', payee: 'STARBUCKS', amountCents: -500),
+              ]);
+      when(() => mockAutoCatRepo.getCacheEntry(any(), any()))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => [rule]);
+      when(() => mockTxnRepo.updateCategory(any(), any()))
+          .thenAnswer((_) async {});
+      // Make the flush throw — this happens after all transactions are
+      // already categorized. The user-visible count must still be 1.
+      when(() => mockAutoCatRepo.incrementHitCounts(any(), any()))
+          .thenThrow(Exception('disk full'));
+
+      final count = await service.categorizeUncategorized();
+
+      expect(count, equals(1));
+      verify(() => mockTxnRepo.updateCategory('txn-1', 'cat-x')).called(1);
+    });
+
     test('skips flush when no rules matched', () async {
       final txns = [
         _makeTransaction(id: 'txn-1', payee: 'UNKNOWN', amountCents: -500),

--- a/test/unit/usecases/auto_categorize_service_test.dart
+++ b/test/unit/usecases/auto_categorize_service_test.dart
@@ -24,6 +24,11 @@ void main() {
     mockAutoCatRepo = MockAutoCategorizeRepository();
     mockTxnRepo = MockTransactionRepository();
     service = AutoCategorizeService(mockAutoCatRepo, mockTxnRepo);
+    // Default stub for the hit-count flush so categorizeUncategorized
+    // calls in tests don't fail with MissingStubError when they don't
+    // care about hit-count accumulation.
+    when(() => mockAutoCatRepo.incrementHitCounts(any(), any()))
+        .thenAnswer((_) async {});
   });
 
   setUpAll(() {
@@ -727,6 +732,57 @@ void main() {
       expect(count, equals(0));
       verifyNever(() => mockAutoCatRepo.getEnabledRules());
     });
+
+    test(
+        'accumulates rule hit counts across the loop and flushes once at the end',
+        () async {
+      final rule = _makeRule(
+        id: 'rule-dining',
+        payeeContains: 'STARBUCKS',
+        categoryId: 'cat-dining',
+        priority: 10,
+      );
+      final txns = [
+        _makeTransaction(id: 'txn-1', payee: 'STARBUCKS NYC', amountCents: -500),
+        _makeTransaction(id: 'txn-2', payee: 'STARBUCKS LA', amountCents: -400),
+        _makeTransaction(id: 'txn-3', payee: 'STARBUCKS SF', amountCents: -700),
+        _makeTransaction(id: 'txn-4', payee: 'UNKNOWN', amountCents: -1000),
+      ];
+      when(() => mockTxnRepo.getUncategorizedTransactions())
+          .thenAnswer((_) async => txns);
+      when(() => mockAutoCatRepo.getCacheEntry(any(), any()))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => [rule]);
+      when(() => mockTxnRepo.updateCategory(any(), any()))
+          .thenAnswer((_) async {});
+
+      final count = await service.categorizeUncategorized();
+
+      expect(count, equals(3));
+      // The matching rule should have its hit count incremented by 3 in
+      // a single batched flush — not 3 separate single-row writes.
+      verify(() => mockAutoCatRepo.incrementHitCounts({'rule-dining': 3}, any()))
+          .called(1);
+    });
+
+    test('skips flush when no rules matched', () async {
+      final txns = [
+        _makeTransaction(id: 'txn-1', payee: 'UNKNOWN', amountCents: -500),
+      ];
+      when(() => mockTxnRepo.getUncategorizedTransactions())
+          .thenAnswer((_) async => txns);
+      when(() => mockAutoCatRepo.getCacheEntry(any(), any()))
+          .thenAnswer((_) async => null);
+      when(() => mockAutoCatRepo.getEnabledRules())
+          .thenAnswer((_) async => []);
+
+      final count = await service.categorizeUncategorized();
+
+      expect(count, 0);
+      verifyNever(() =>
+          mockAutoCatRepo.incrementHitCounts(any(), any()));
+    });
   });
 
   group('categorizeUncategorized with accountType', () {
@@ -1263,7 +1319,7 @@ AutoCategorizeRule _makeRule({
     accountId: accountId,
     accountType: accountType,
     categoryId: categoryId,
-    isEnabled: true,
+    isEnabled: true, hitCount: 0,
     createdAt: 0,
     updatedAt: 0,
   );

--- a/test/unit/usecases/categorize/rule_conflicts_test.dart
+++ b/test/unit/usecases/categorize/rule_conflicts_test.dart
@@ -20,7 +20,7 @@ AutoCategorizeRule _rule({
     accountId: null,
     categoryId: categoryId,
     accountType: null,
-    isEnabled: true,
+    isEnabled: true, hitCount: 0,
     createdAt: 0,
     updatedAt: 0,
   );

--- a/test/unit/usecases/categorize/rule_seeder_test.dart
+++ b/test/unit/usecases/categorize/rule_seeder_test.dart
@@ -65,7 +65,7 @@ void main() {
       accountId: null,
       categoryId: categoryId,
       accountType: null,
-      isEnabled: true,
+      isEnabled: true, hitCount: 0,
       createdAt: createdAt,
       updatedAt: updatedAt,
     );
@@ -208,7 +208,7 @@ void main() {
               accountId: null,
               categoryId: 'trans',
               accountType: null,
-              isEnabled: true,
+              isEnabled: true, hitCount: 0,
               createdAt: 1000,
               updatedAt: 1000,
             ),
@@ -351,7 +351,7 @@ void main() {
               accountId: null,
               categoryId: 'gas',
               accountType: null,
-              isEnabled: false, // user disabled
+              isEnabled: false, hitCount: 0, // user disabled
               createdAt: 1000,
               updatedAt: 2000,
             ),
@@ -391,7 +391,7 @@ void main() {
               accountId: null,
               categoryId: 'misc', // user mapped it elsewhere
               accountType: null,
-              isEnabled: true,
+              isEnabled: true, hitCount: 0,
               createdAt: 1000,
               updatedAt: 2000,
             ),

--- a/test/unit/usecases/import/csv_import_service_test.dart
+++ b/test/unit/usecases/import/csv_import_service_test.dart
@@ -27,6 +27,19 @@ void main() {
     mockAutoCatService = MockAutoCategorizeService();
     service = CsvImportService(mockTxnRepo, mockImportRepo, mockAutoCatService);
     tempDir = Directory.systemTemp.createTempSync('csv_import_test_');
+    // Default no-match trace stub so tests that don't care about
+    // categorization don't need to wire one up explicitly.
+    when(() => mockAutoCatService.categorizeWithPreloadedRulesAndTrace(
+          any(), any(),
+          amountCents: any(named: 'amountCents'),
+          accountId: any(named: 'accountId'),
+          accountType: any(named: 'accountType'),
+        )).thenAnswer((_) async => const CategorizationTrace(
+          normalizedPayee: '',
+          source: CategorizationSource.none,
+        ));
+    when(() => mockAutoCatService.flushHitCounts(any()))
+        .thenAnswer((_) async {});
   });
 
   tearDown(() {
@@ -560,12 +573,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 
@@ -600,12 +607,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 
@@ -660,14 +661,23 @@ void main() {
 
       // First call matches, second doesn't
       var callCount = 0;
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
+      when(() => mockAutoCatService.categorizeWithPreloadedRulesAndTrace(
             any(),
             any(),
             amountCents: any(named: 'amountCents'),
             accountId: any(named: 'accountId'),
           )).thenAnswer((_) async {
         callCount++;
-        return callCount == 1 ? 'cat-dining' : null;
+        return callCount == 1
+            ? const CategorizationTrace(
+                categoryId: 'cat-dining',
+                normalizedPayee: 'STARBUCKS',
+                source: CategorizationSource.rule,
+              )
+            : const CategorizationTrace(
+                normalizedPayee: '',
+                source: CategorizationSource.none,
+              );
       });
       when(() => mockTxnRepo.updateCategory(any(), any()))
           .thenAnswer((_) async {});
@@ -694,12 +704,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 
@@ -743,12 +747,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 
@@ -774,12 +772,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 
@@ -844,12 +836,6 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockAutoCatService.loadEnabledRules())
           .thenAnswer((_) async => []);
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(),
-            any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-          )).thenAnswer((_) async => null);
       when(() => mockImportRepo.insertImportRecord(any()))
           .thenAnswer((_) async {});
 

--- a/test/unit/usecases/sync/simplefin_sync_service_test.dart
+++ b/test/unit/usecases/sync/simplefin_sync_service_test.dart
@@ -195,6 +195,19 @@ void main() {
         .thenAnswer((_) async => const SimplefinAccountsResponse(accounts: []));
     when(() => mockAutoCatService.loadEnabledRules())
         .thenAnswer((_) async => []);
+    // Default no-match for the trace-variant categorize call so per-test
+    // stubs only need to override the cases they care about.
+    when(() => mockAutoCatService.categorizeWithPreloadedRulesAndTrace(
+          any(), any(),
+          amountCents: any(named: 'amountCents'),
+          accountId: any(named: 'accountId'),
+          accountType: any(named: 'accountType'),
+        )).thenAnswer((_) async => const CategorizationTrace(
+          normalizedPayee: '',
+          source: CategorizationSource.none,
+        ));
+    when(() => mockAutoCatService.flushHitCounts(any()))
+        .thenAnswer((_) async {});
     when(() => mockAccountRepo.getAccountsByConnection(connectionId))
         .thenAnswer((_) async => []);
     when(() => mockTxnRepo.getExternalIdsByPrefix(any(), any()))
@@ -296,13 +309,6 @@ void main() {
       // getFuzzyMatchCandidates already stubbed in stubBasicSuccessfulSync
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(), any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-            accountType: any(named: 'accountType'),
-          )).thenAnswer((_) async => null);
-
       when(() => mockClient.getAccounts(any(),
               includePending: any(named: 'includePending')))
           .thenAnswer((_) async => const SimplefinAccountsResponse(
@@ -485,12 +491,16 @@ void main() {
           .thenAnswer((_) async {});
       when(() => mockTxnRepo.updateCategory(any(), any()))
           .thenAnswer((_) async {});
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
+      when(() => mockAutoCatService.categorizeWithPreloadedRulesAndTrace(
             any(), any(),
             amountCents: any(named: 'amountCents'),
             accountId: any(named: 'accountId'),
             accountType: any(named: 'accountType'),
-          )).thenAnswer((_) async => 'cat-dining');
+          )).thenAnswer((_) async => const CategorizationTrace(
+            categoryId: 'cat-dining',
+            normalizedPayee: 'STARBUCKS',
+            source: CategorizationSource.rule,
+          ));
 
       when(() => mockClient.getAccounts(any(),
               includePending: any(named: 'includePending')))
@@ -683,13 +693,6 @@ void main() {
       // getFuzzyMatchCandidates already stubbed in stubBasicSuccessfulSync
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(), any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-            accountType: any(named: 'accountType'),
-          )).thenAnswer((_) async => null);
-
       when(() => mockClient.getAccounts(any(),
               includePending: any(named: 'includePending')))
           .thenAnswer((_) async => const SimplefinAccountsResponse(
@@ -820,13 +823,6 @@ void main() {
       // getFuzzyMatchCandidates already stubbed in stubBasicSuccessfulSync
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(), any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-            accountType: any(named: 'accountType'),
-          )).thenAnswer((_) async => null);
-
       when(() => mockClient.getAccounts(any(),
               includePending: any(named: 'includePending')))
           .thenAnswer((_) async => const SimplefinAccountsResponse(
@@ -969,12 +965,8 @@ void main() {
       // getFuzzyMatchCandidates already stubbed in stubBasicSuccessfulSync
       when(() => mockTxnRepo.insertTransaction(any()))
           .thenAnswer((_) async {});
-      when(() => mockAutoCatService.categorizeWithPreloadedRules(
-            any(), any(),
-            amountCents: any(named: 'amountCents'),
-            accountId: any(named: 'accountId'),
-            accountType: any(named: 'accountType'),
-          )).thenAnswer((_) async => null);
+      // default trace stub from stubBasicSuccessfulSync returns none; that's
+      // fine for this test which only checks the call's accountId/amount.
 
       when(() => mockClient.getAccounts(any(),
               includePending: any(named: 'includePending')))
@@ -1000,7 +992,7 @@ void main() {
 
       await service.syncConnection(connectionId);
 
-      verify(() => mockAutoCatService.categorizeWithPreloadedRules(
+      verify(() => mockAutoCatService.categorizeWithPreloadedRulesAndTrace(
             any(), any(),
             amountCents: -500, // negated
             accountId: accountId,


### PR DESCRIPTION
## Summary

Schema migration **v7 → v8**: adds `hit_count` (INTEGER, default 0) and `last_hit_at` (INTEGER, nullable) to `auto_categorize_rules`. Wrapped in a transaction so partial failure leaves the schema at v7.

**Hit-count accumulation** lives in the bulk-categorize paths only:
- `categorizeWithPreloadedRulesAndTrace` (the trace variant) stays pure — single source of truth, no side effects from a "what would match?" query
- Each caller builds a `Map<ruleId, int>` of hits and calls `AutoCategorizeService.flushHitCounts(...)` at the end, which writes the whole batch in one Drift batch

**Three wired call sites:**
- `categorizeUncategorized` — the Re-categorize button
- `SimplefinSyncService.syncConnection` — accumulates across all accounts on the connection, flushes before recording history
- `CsvImportService.executeImport` — accumulates across all imported rows, flushes after the loop

The single-tx suggestion path (`_onPayeeChanged` in the add/edit transaction screen) intentionally does NOT increment hits — the user may reject the suggestion. Hits measure rule-driven categorizations that were actually applied.

**Repo:** `incrementHitCounts(Map<String,int>, int)` uses raw SQL `hit_count = hit_count + ?` inside a Drift batch, so concurrent flushes from sync + import + manual would compose correctly.

**UI:**
- `_RuleTile` subtitle shows `"42 hits"` / `"Never used"`
- AppBar sort menu: Priority (default) / Name / Most hits / Recently used. Drag-reorder is suppressed outside the priority sort because the visual order wouldn't match the priority axis
- FilterChip **"Low-use rules"** — `hit_count == 0` AND `createdAt < now - 90 days` (same window the rule-suggestion banner will use in 3.4)

## Test plan

- [x] `flutter analyze` clean on touched files
- [x] All 339 tests pass (added: 3 repo tests for `incrementHitCounts`, 2 service tests for `categorizeUncategorized` accumulation)
- [x] Updated sync + csv test mocks to default-stub the trace variant + `flushHitCounts`; redundant per-test null stubs removed
- [x] Updated `AutoCategorizeRule` fixtures across 3 test files for the new `hitCount` required-named parameter
- [ ] Manual: run the Re-categorize button → some rules' hit_count goes up → UI shows new badges
- [ ] Manual: low-use FilterChip filters to never-used rules created over 90 days ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)